### PR TITLE
Rename IPPort to ServerAddress and add server ids

### DIFF
--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -3,9 +3,9 @@ __version__ = "0.1.0"
 from meta_memcache.base.base_write_failure_tracker import BaseWriteFailureTracker
 from meta_memcache.cache_pools import ShardedCachePool, ShardedWithGutterCachePool
 from meta_memcache.configuration import (
-    IPPort,
     LeasePolicy,
     RecachePolicy,
+    ServerAddress,
     StalePolicy,
     connection_pool_factory_builder,
     socket_factory_builder,

--- a/src/meta_memcache/base/connection_pool.py
+++ b/src/meta_memcache/base/connection_pool.py
@@ -35,7 +35,7 @@ class ConnectionPool:
         mark_down_period_s: float = DEFAULT_MARK_DOWN_PERIOD_S,
         read_buffer_size: int = DEFAULT_READ_BUFFER_SIZE,
     ) -> None:
-        self._server = server
+        self.server = server
         self._socket_factory_fn = socket_factory_fn
         self._initial_pool_size: int = min(initial_pool_size, max_pool_size)
         self._max_pool_size = max_pool_size
@@ -73,7 +73,7 @@ class ConnectionPool:
         if marked_down_until := self._marked_down_until:
             if time.time() < marked_down_until:
                 raise MemcacheServerError(
-                    self._server, f"Server marked down: {self._server}"
+                    self.server, f"Server marked down: {self.server}"
                 )
             self._marked_down_until = None
 
@@ -83,7 +83,7 @@ class ConnectionPool:
             self._errors = next(self._errors_counter)
             self._marked_down_until = time.time() + self._mark_down_period_s
             raise MemcacheServerError(
-                self._server, f"Server marked down: {self._server}"
+                self.server, f"Server marked down: {self.server}"
             ) from e
 
         self._created = next(self._created_counter)

--- a/tests/cache_pools_test.py
+++ b/tests/cache_pools_test.py
@@ -27,15 +27,15 @@ def test_sharded_cache_pool(mocker: MockerFixture) -> None:
     )
     connection_pool = cache_pool._get_pool(Key("foo"))
     assert isinstance(connection_pool, ConnectionPool)
-    assert connection_pool._server == "2.2.2.2:11211"
+    assert connection_pool.server == "2.2.2.2:11211"
 
     connection_pool = cache_pool._get_pool(Key("bar"))
     assert isinstance(connection_pool, ConnectionPool)
-    assert connection_pool._server == "1.1.1.1:11211"
+    assert connection_pool.server == "1.1.1.1:11211"
 
     connection_pool = cache_pool._get_pool(Key("bar", routing_key="foo"))
     assert isinstance(connection_pool, ConnectionPool)
-    assert connection_pool._server == "2.2.2.2:11211"
+    assert connection_pool.server == "2.2.2.2:11211"
 
 
 def test_sharded_cache_pool_different_order_same_results(mocker: MockerFixture) -> None:
@@ -52,15 +52,15 @@ def test_sharded_cache_pool_different_order_same_results(mocker: MockerFixture) 
     )
     connection_pool = cache_pool._get_pool(Key("foo"))
     assert isinstance(connection_pool, ConnectionPool)
-    assert connection_pool._server == "2.2.2.2:11211"
+    assert connection_pool.server == "2.2.2.2:11211"
 
     connection_pool = cache_pool._get_pool(Key("bar"))
     assert isinstance(connection_pool, ConnectionPool)
-    assert connection_pool._server == "1.1.1.1:11211"
+    assert connection_pool.server == "1.1.1.1:11211"
 
     connection_pool = cache_pool._get_pool(Key("bar", routing_key="foo"))
     assert isinstance(connection_pool, ConnectionPool)
-    assert connection_pool._server == "2.2.2.2:11211"
+    assert connection_pool.server == "2.2.2.2:11211"
 
 
 def test_sharded_cache_pool_honors_server_id(mocker: MockerFixture) -> None:
@@ -82,9 +82,9 @@ def test_sharded_cache_pool_honors_server_id(mocker: MockerFixture) -> None:
         connection_pool_factory_fn=connection_pool_factory_builder(),
     )
     connection_pool = cache_pool_a._get_pool(Key("foo"))
-    assert connection_pool._server == "1"
+    assert connection_pool.server == "1"
     connection_pool = cache_pool_b._get_pool(Key("foo"))
-    assert connection_pool._server == "1"
+    assert connection_pool.server == "1"
 
 
 def test_sharded_with_gutter_cache_pool(mocker: MockerFixture) -> None:
@@ -117,7 +117,7 @@ def test_sharded_with_gutter_cache_pool(mocker: MockerFixture) -> None:
 
     connection_pool = cache_pool._get_pool(Key("foo"))
     assert isinstance(connection_pool, ConnectionPool)
-    assert connection_pool._server == "ko2:11211"
+    assert connection_pool.server == "ko2:11211"
     assert connection_pool._pool.qsize() == 0
     assert connection_pool.get_counters() == PoolCounters(
         available=0,
@@ -129,7 +129,7 @@ def test_sharded_with_gutter_cache_pool(mocker: MockerFixture) -> None:
 
     connection_pool = cache_pool._get_pool(Key("bar"))
     assert isinstance(connection_pool, ConnectionPool)
-    assert connection_pool._server == "ok1:11211"
+    assert connection_pool.server == "ok1:11211"
     assert connection_pool._pool.qsize() == 2
     assert connection_pool.get_counters() == PoolCounters(
         available=2,

--- a/tests/cache_pools_test.py
+++ b/tests/cache_pools_test.py
@@ -4,8 +4,8 @@ from typing import Tuple
 from pytest_mock import MockerFixture
 
 from meta_memcache import (
-    IPPort,
     Key,
+    ServerAddress,
     ShardedCachePool,
     ShardedWithGutterCachePool,
     connection_pool_factory_builder,
@@ -17,11 +17,11 @@ from meta_memcache.settings import DEFAULT_MARK_DOWN_PERIOD_S
 
 def test_sharded_cache_pool(mocker: MockerFixture) -> None:
     mocker.patch("meta_memcache.configuration.socket", autospec=True)
-    cache_pool = ShardedCachePool.from_ipport_list(
+    cache_pool = ShardedCachePool.from_server_addresses(
         servers=[
-            IPPort(ip="1.1.1.1", port=11211),
-            IPPort(ip="2.2.2.2", port=11211),
-            IPPort(ip="3.3.3.3", port=11211),
+            ServerAddress(host="1.1.1.1", port=11211),
+            ServerAddress(host="2.2.2.2", port=11211),
+            ServerAddress(host="3.3.3.3", port=11211),
         ],
         connection_pool_factory_fn=connection_pool_factory_builder(),
     )
@@ -40,14 +40,14 @@ def test_sharded_cache_pool(mocker: MockerFixture) -> None:
 
 def test_sharded_cache_pool_different_order_same_results(mocker: MockerFixture) -> None:
     mocker.patch("meta_memcache.configuration.socket", autospec=True)
-    server_list = [
-        IPPort(ip="1.1.1.1", port=11211),
-        IPPort(ip="2.2.2.2", port=11211),
-        IPPort(ip="3.3.3.3", port=11211),
+    server_addresses = [
+        ServerAddress(host="1.1.1.1", port=11211),
+        ServerAddress(host="2.2.2.2", port=11211),
+        ServerAddress(host="3.3.3.3", port=11211),
     ]
-    random.shuffle(server_list)
-    cache_pool = ShardedCachePool.from_ipport_list(
-        servers=server_list,
+    random.shuffle(server_addresses)
+    cache_pool = ShardedCachePool.from_server_addresses(
+        servers=server_addresses,
         connection_pool_factory_fn=connection_pool_factory_builder(),
     )
     connection_pool = cache_pool._get_pool(Key("foo"))
@@ -63,29 +63,53 @@ def test_sharded_cache_pool_different_order_same_results(mocker: MockerFixture) 
     assert connection_pool._server == "2.2.2.2:11211"
 
 
+def test_sharded_cache_pool_honors_server_id(mocker: MockerFixture) -> None:
+    mocker.patch("meta_memcache.configuration.socket", autospec=True)
+    server_addresses = [
+        ServerAddress(host="1.1.1.1", port=11211, server_id="1"),
+        ServerAddress(host="2.2.2.2", port=11211, server_id="2"),
+    ]
+    cache_pool_a = ShardedCachePool.from_server_addresses(
+        servers=server_addresses,
+        connection_pool_factory_fn=connection_pool_factory_builder(),
+    )
+    server_addresses = [
+        ServerAddress(host="1.1.1.1", port=11211, server_id="2"),
+        ServerAddress(host="2.2.2.2", port=11211, server_id="1"),
+    ]
+    cache_pool_b = ShardedCachePool.from_server_addresses(
+        servers=server_addresses,
+        connection_pool_factory_fn=connection_pool_factory_builder(),
+    )
+    connection_pool = cache_pool_a._get_pool(Key("foo"))
+    assert connection_pool._server == "1"
+    connection_pool = cache_pool_b._get_pool(Key("foo"))
+    assert connection_pool._server == "1"
+
+
 def test_sharded_with_gutter_cache_pool(mocker: MockerFixture) -> None:
     server_is_bad = True
 
-    def connect(ip_port: Tuple[str, int]) -> None:
-        ip, port = ip_port
-        if server_is_bad and ip.startswith("ko"):
-            raise MemcacheServerError(server=f"{ip}:{port}", message="uh-oh")
+    def connect(server_address: Tuple[str, int]) -> None:
+        host, port = server_address
+        if server_is_bad and host.startswith("ko"):
+            raise MemcacheServerError(server=f"{host}:{port}", message="uh-oh")
 
     time = mocker.patch("meta_memcache.base.connection_pool.time")
     time.time.return_value = 123
     socket = mocker.patch("meta_memcache.configuration.socket", autospec=True)
     c = socket.socket()
     c.connect.side_effect = connect
-    cache_pool = ShardedWithGutterCachePool.from_ipport_list(
+    cache_pool = ShardedWithGutterCachePool.from_server_addresses(
         servers=[
-            IPPort(ip="ok1", port=11211),
-            IPPort(ip="ko2", port=11211),
-            IPPort(ip="ok3", port=11211),
+            ServerAddress(host="ok1", port=11211),
+            ServerAddress(host="ko2", port=11211),
+            ServerAddress(host="ok3", port=11211),
         ],
         gutter_servers=[
-            IPPort(ip="gutter1", port=11211),
-            IPPort(ip="gutter2", port=11211),
-            IPPort(ip="gutter3", port=11211),
+            ServerAddress(host="gutter1", port=11211),
+            ServerAddress(host="gutter2", port=11211),
+            ServerAddress(host="gutter3", port=11211),
         ],
         gutter_ttl=60,
         connection_pool_factory_fn=connection_pool_factory_builder(initial_pool_size=2),


### PR DESCRIPTION
## Motivation / Description
uhashring's HashRing uses str() on the entities added to the
ring to generate the hashes and the corresponding shardmap.

To mimic bmemcached behavior we need to customize the server
ids we use, so we get exactly the same shard map as before.

In general, controlling the server id can lead to better
management of the pool. If you want, for example, to replace
a server with another, if the server id is kept constant
you avoid any shardmap changes at all.

## Changes introduced
* Rename IPPort to ServerAddress and also related methods
* Add server_id, so the HashRing behavior can be controlled
  easily with the pool configuration
