### PR TITLE
Support strings for keys on high-level commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ cache_pool.set(key=Key("bar"), value=1, ttl=1000)
 ```
 
 ## Keys:
+### String or `Key` named tuple
+On the high-level commands you can use either plain strings as keys
+or the more advanced `Key` object that allows extra features like
+custom routing and unicode keys.
 
 ### Custom routing:
 You can control the routing of the keys setting a custom `routing_key`:
@@ -190,7 +194,7 @@ Invalidation...
 ```python:
     def set(
         self,
-        key: Key,
+        key: Union[Key, str],
         value: Any,
         ttl: int,
         no_reply: bool = False,
@@ -200,7 +204,7 @@ Invalidation...
 
     def delete(
         self,
-        key: Key,
+        key: Union[Key, str],
         cas_token: Optional[int] = None,
         no_reply: bool = False,
         stale_policy: Optional[StalePolicy] = None,
@@ -208,14 +212,14 @@ Invalidation...
 
     def touch(
         self,
-        key: Key,
+        key: Union[Key, str],
         ttl: int,
         no_reply: bool = False,
     ) -> bool:
 
     def get_or_lease(
         self,
-        key: Key,
+        key: Union[Key, str],
         lease_policy: LeasePolicy,
         touch_ttl: Optional[int] = None,
         recache_policy: Optional[RecachePolicy] = None,
@@ -223,7 +227,7 @@ Invalidation...
 
     def get_or_lease_cas(
         self,
-        key: Key,
+        key: Union[Key, str],
         lease_policy: LeasePolicy,
         touch_ttl: Optional[int] = None,
         recache_policy: Optional[RecachePolicy] = None,
@@ -231,28 +235,28 @@ Invalidation...
 
     def get(
         self,
-        key: Key,
+        key: Union[Key, str],
         touch_ttl: Optional[int] = None,
         recache_policy: Optional[RecachePolicy] = None,
     ) -> Optional[Any]:
 
     def multi_get(
         self,
-        keys: List[Key],
+        keys: List[Union[Key, str]],
         touch_ttl: Optional[int] = None,
         recache_policy: Optional[RecachePolicy] = None,
     ) -> Dict[Key, Optional[Any]]:
 
     def get_cas(
         self,
-        key: Key,
+        key: Union[Key, str],
         touch_ttl: Optional[int] = None,
         recache_policy: Optional[RecachePolicy] = None,
     ) -> Tuple[Optional[Any], Optional[int]]:
 
     def get_typed(
         self,
-        key: Key,
+        key: Union[Key, str],
         cls: Type[T],
         touch_ttl: Optional[int] = None,
         recache_policy: Optional[RecachePolicy] = None,
@@ -261,7 +265,7 @@ Invalidation...
 
     def get_cas_typed(
         self,
-        key: Key,
+        key: Union[Key, str],
         cls: Type[T],
         touch_ttl: Optional[int] = None,
         recache_policy: Optional[RecachePolicy] = None,
@@ -270,7 +274,7 @@ Invalidation...
 
     def delta(
         self,
-        key: Key,
+        key: Union[Key, str],
         delta: int,
         refresh_ttl: Optional[int] = None,
         no_reply: bool = False,
@@ -279,7 +283,7 @@ Invalidation...
 
     def delta_initialize(
         self,
-        key: Key,
+        key: Union[Key, str],
         delta: int,
         initial_value: int,
         initial_ttl: int,
@@ -290,7 +294,7 @@ Invalidation...
 
     def delta_and_get(
         self,
-        key: Key,
+        key: Union[Key, str],
         delta: int,
         refresh_ttl: Optional[int] = None,
         cas_token: Optional[int] = None,
@@ -298,7 +302,7 @@ Invalidation...
 
     def delta_initialize_and_get(
         self,
-        key: Key,
+        key: Union[Key, str],
         delta: int,
         initial_value: int,
         initial_ttl: int,

--- a/tests/base/cache_pool_test.py
+++ b/tests/base/cache_pool_test.py
@@ -74,6 +74,12 @@ def test_set_cmd(
 ) -> None:
     memcache_socket.get_response.return_value = Success()
 
+    cache_pool.set(key="foo", value="bar", ttl=300)
+    memcache_socket.sendall.assert_called_once_with(b"ms foo 3 T300 F0\r\nbar\r\n")
+    memcache_socket.get_response.assert_called_once_with()
+    memcache_socket.sendall.reset_mock()
+    memcache_socket.get_response.reset_mock()
+
     cache_pool.set(key=Key("foo"), value="bar", ttl=300)
     memcache_socket.sendall.assert_called_once_with(b"ms foo 3 T300 F0\r\nbar\r\n")
     memcache_socket.get_response.assert_called_once_with()
@@ -170,6 +176,12 @@ def test_delete_cmd(
 ) -> None:
     memcache_socket.get_response.return_value = Success()
 
+    cache_pool.delete(key="foo")
+    memcache_socket.sendall.assert_called_once_with(b"md foo\r\n")
+    memcache_socket.get_response.assert_called_once_with()
+    memcache_socket.sendall.reset_mock()
+    memcache_socket.get_response.reset_mock()
+
     cache_pool.delete(key=Key("foo"))
     memcache_socket.sendall.assert_called_once_with(b"md foo\r\n")
     memcache_socket.get_response.assert_called_once_with()
@@ -223,6 +235,12 @@ def test_touch_cmd(
 ) -> None:
     memcache_socket.get_response.return_value = Success()
 
+    cache_pool.touch(key="foo", ttl=60)
+    memcache_socket.sendall.assert_called_once_with(b"mg foo T60\r\n")
+    memcache_socket.get_response.assert_called_once_with()
+    memcache_socket.sendall.reset_mock()
+    memcache_socket.get_response.reset_mock()
+
     cache_pool.touch(key=Key("foo"), ttl=60)
     memcache_socket.sendall.assert_called_once_with(b"mg foo T60\r\n")
     memcache_socket.get_response.assert_called_once_with()
@@ -238,6 +256,10 @@ def test_touch_cmd(
 
 def test_get_cmd(memcache_socket: MemcacheSocket, cache_pool: FakeCachePool) -> None:
     memcache_socket.get_response.return_value = Miss()
+
+    cache_pool.get(key="foo")
+    memcache_socket.sendall.assert_called_once_with(b"mg foo t l v c h f\r\n")
+    memcache_socket.sendall.reset_mock()
 
     cache_pool.get(key=Key("foo"))
     memcache_socket.sendall.assert_called_once_with(b"mg foo t l v c h f\r\n")
@@ -695,6 +717,10 @@ def test_write_failure_tracker(
 
 def test_delta_cmd(memcache_socket: MemcacheSocket, cache_pool: FakeCachePool) -> None:
     memcache_socket.get_response.return_value = Miss()
+
+    cache_pool.delta(key="foo", delta=1, no_reply=True)
+    memcache_socket.sendall.assert_called_once_with(b"ma foo q D1\r\n")
+    memcache_socket.sendall.reset_mock()
 
     cache_pool.delta(key=Key("foo"), delta=1, no_reply=True)
     memcache_socket.sendall.assert_called_once_with(b"ma foo q D1\r\n")


### PR DESCRIPTION
For convenience and simplicity, as most people won't
need advanced routing or unicode keys, the high-level
commands now accept strings as keys.

Internally, it still uses `Key` named tuple.
