### PR TITLE
Add set modes (add, replace, append and prepend)

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Invalidation...
         no_reply: bool = False,
         cas_token: Optional[int] = None,
         stale_policy: Optional[StalePolicy] = None,
+        set_mode: SetMode = SetMode.SET,  # Other are ADD, REPLACE, APPEND...
     ) -> bool:
 
     def delete(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meta-memcache"
-version = "0.3.0"
+version = "0.4.0"
 description = "Modern, pure python, memcache client with support for new meta commands."
 license = "MIT"
 readme = "README.md"

--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -1,6 +1,7 @@
 __version__ = "0.1.0"
 
 from meta_memcache.base.base_write_failure_tracker import BaseWriteFailureTracker
+from meta_memcache.base.cache_pool import CachePool, SetMode
 from meta_memcache.cache_pools import ShardedCachePool, ShardedWithGutterCachePool
 from meta_memcache.configuration import (
     LeasePolicy,

--- a/src/meta_memcache/protocol.py
+++ b/src/meta_memcache/protocol.py
@@ -56,7 +56,17 @@ class IntFlag(Enum):
 class TokenFlag(Enum):
     OPAQUE = b"O"
     KEY = b"k"
-    MA_MODE = b"M"  # mode switch. I or + / D or - for incr / decr
+    # 'M' (mode switch):
+    # * Meta Arithmetic:
+    #  - I or +: increment
+    #  - D or -: decrement
+    # * Meta Set: See SetMode Enum in base/cache_pool.py
+    #  - E: "add" command. LRU bump and return NS if item exists. Else add.
+    #  - A: "append" command. If item exists, append the new value to its data.
+    #  - P: "prepend" command. If item exists, prepend the new value to its data.
+    #  - R: "replace" command. Set only if item already exists.
+    #  - S: "set" command. The default mode, added for completeness.
+    MODE = b"M"
 
 
 # Store maps of byte values (int) to enum value


### PR DESCRIPTION
Support the Mode flag on set command to support the
alternative set modes:

Meta flag values:
* E: "add" command. LRU bump and return NS if item exists. Else
add.
* A: "append" command. If item exists, append the new value to its data.
* P: "prepend" command. If item exists, prepend the new value to its data.
* R: "replace" command. Set only if item already exists.
* S: "set" command. The default mode, added for completeness.

This is exposed in the high level API as a `set_mode` argument:
```
    def set(
        self,
        key: Key,
        value: Any,  # pyre-ignore[2]
        ttl: int,
        no_reply: bool = False,
        cas_token: Optional[int] = None,
        stale_policy: Optional[StalePolicy] = None,
        set_mode: SetMode = SetMode.SET,
    ) -> bool:
```

The `SetMode` enum is:

```
class SetMode(Enum):
    SET = b"S"  # Default
    ADD = b"E"  # LRU bump and return NS if item exists. Else add.
    APPEND = b"A"  # If item exists, append the new value to its data.
    PREPEND = b"P"  # If item exists, prepend the new value to its data.
    REPLACE = b"R"  # Set only if item already exists.
```
