### PR TITLE
Support memcache 1.6.6 meta commands

### DIFF
--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -19,6 +19,7 @@ from meta_memcache.protocol import (
     Key,
     Miss,
     NotStored,
+    ServerVersion,
     Success,
     TokenFlag,
     Value,

--- a/src/meta_memcache/base/base_cache_pool.py
+++ b/src/meta_memcache/base/base_cache_pool.py
@@ -19,10 +19,12 @@ from meta_memcache.protocol import (
     Miss,
     NotStored,
     ReadResponse,
+    ServerVersion,
     Success,
     TokenFlag,
     Value,
     WriteResponse,
+    encode_size,
 )
 from meta_memcache.settings import MAX_KEY_SIZE
 
@@ -56,11 +58,12 @@ class BaseCachePool(ABC):
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        version: ServerVersion = ServerVersion.STABLE,
     ) -> bytes:
         encoded_key, is_binary = self._encode_key(key)
         cmd = [command.value, encoded_key]
         if size is not None:
-            cmd.append(str(size).encode("ascii"))
+            cmd.append(encode_size(size, version=version))
         cmd_flags = []
         if is_binary:
             cmd_flags.append(Flag.BINARY.value)
@@ -173,6 +176,7 @@ class BaseCachePool(ABC):
             flags=flags,
             int_flags=int_flags,
             token_flags=token_flags,
+            version=conn.get_version(),
         )
         if value:
             conn.sendall(cmd + value + ENDL)

--- a/src/meta_memcache/base/cache_pool.py
+++ b/src/meta_memcache/base/cache_pool.py
@@ -1,6 +1,6 @@
-from enum import Enum
 import time
-from typing import Any, Dict, List, Optional, Set, Tuple, Type, TypeVar, Union
+from enum import Enum
+from typing import Any, Dict, Iterable, Optional, Set, Tuple, Type, TypeVar, Union
 
 from meta_memcache.base.base_cache_pool import BaseCachePool
 from meta_memcache.configuration import LeasePolicy, RecachePolicy, StalePolicy
@@ -195,7 +195,7 @@ class CachePool(BaseCachePool):
     # pyre-ignore[3]  Yeah, we return 'Any'
     def multi_get(
         self,
-        keys: List[Union[Key, str]],
+        keys: Iterable[Union[Key, str]],
         touch_ttl: Optional[int] = None,
         recache_policy: Optional[RecachePolicy] = None,
     ) -> Dict[Key, Optional[Any]]:

--- a/src/meta_memcache/configuration.py
+++ b/src/meta_memcache/configuration.py
@@ -3,7 +3,7 @@ import socket
 from typing import Callable, NamedTuple, Optional
 
 from meta_memcache.base.connection_pool import ConnectionPool
-from meta_memcache.protocol import Key
+from meta_memcache.protocol import Key, ServerVersion
 from meta_memcache.settings import DEFAULT_MARK_DOWN_PERIOD_S
 
 
@@ -19,6 +19,7 @@ class ServerAddress(NamedTuple):
     # use numerical server_ids, and change the destination
     # IP maintaining the server_id for clean swaps.
     server_id: Optional[str] = None
+    version: ServerVersion = ServerVersion.STABLE
 
     def __str__(self) -> str:
         if self.server_id is not None:
@@ -90,6 +91,7 @@ def connection_pool_factory_builder(
             max_pool_size=max_pool_size,
             mark_down_period_s=mark_down_period_s,
             read_buffer_size=read_buffer_size,
+            version=server_address.version,
         )
 
     return connection_pool_builder

--- a/src/meta_memcache/protocol.py
+++ b/src/meta_memcache/protocol.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import Any, Dict, NamedTuple, Optional, Set, Union
 
 ENDL = b"\r\n"
@@ -133,3 +133,28 @@ WriteResponse = Union[Success, NotStored, Conflict, Miss]
 
 
 Blob = Union[bytes, bytearray, memoryview]
+
+
+class ServerVersion(IntEnum):
+    """
+    If more versions with breaking changes are
+    added, bump stable to the next int. Code
+    will be able to use > / < / = to code
+    the behavior of the different versions.
+    """
+
+    AWS_1_6_6 = 1
+    STABLE = 2
+
+
+def get_store_success_response_header(version: ServerVersion) -> bytes:
+    if version == ServerVersion.AWS_1_6_6:
+        return b"OK"
+    return b"HD"
+
+
+def encode_size(size: int, version: ServerVersion) -> bytes:
+    if version == ServerVersion.AWS_1_6_6:
+        return b"S" + str(size).encode("ascii")
+    else:
+        return str(size).encode("ascii")

--- a/tests/base/memcache_socket_test.py
+++ b/tests/base/memcache_socket_test.py
@@ -12,6 +12,7 @@ from meta_memcache.protocol import (
     IntFlag,
     Miss,
     NotStored,
+    ServerVersion,
     Success,
     TokenFlag,
     Value,
@@ -80,6 +81,23 @@ def test_get_response(
         [b"HD c1\r\nVA 2 c1", b"\r\nOK\r\n"]
     )
     ms = MemcacheSocket(fake_socket)
+    result = ms.get_response()
+    assert isinstance(result, Success)
+    assert result.int_flags == {IntFlag.CAS_TOKEN: 1}
+
+    result = ms.get_response()
+    assert isinstance(result, Value)
+    assert result.int_flags == {IntFlag.CAS_TOKEN: 1}
+    assert result.size == 2
+
+
+def test_get_response_1_6_6(
+    fake_socket: socket.socket,
+) -> None:
+    fake_socket.recv_into.side_effect = recv_into_mock(
+        [b"OK c1\r\nVA 2 c1", b"\r\nOK\r\n"]
+    )
+    ms = MemcacheSocket(fake_socket, version=ServerVersion.AWS_1_6_6)
     result = ms.get_response()
     assert isinstance(result, Success)
     assert result.int_flags == {IntFlag.CAS_TOKEN: 1}


### PR DESCRIPTION
## Motivation / Description
AWS elastic cache only offers ancient version 1.6.6 and breaking
changes were introduced in the meta commands protocol before
declaring it stable.

This implements support for 1.6.6, basically:
- Size in cmd payloads needs to be sent as a flag `cmd S<size>`
  instead of the current protocol `cmd <size> <flags>`
- Store success response is `"OK"` instead of `"HD"`.

There are other minor known issues with 1.6.6:
- `Flag.RETURN_CAS_TOKEN` can't be used in meta sets
- CAS token in meta-delete doesn't work
