### PR TITLE
Switch to deque for ConnectionPool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meta-memcache"
-version = "0.5.0"
+version = "0.6.0"
 description = "Modern, pure python, memcache client with support for new meta commands."
 license = "MIT"
 readme = "README.md"

--- a/src/meta_memcache/base/cache_pool.py
+++ b/src/meta_memcache/base/cache_pool.py
@@ -178,7 +178,7 @@ class CachePool(BaseCachePool):
             else:
                 # With MISS_LEASE_TTL we should always get a value
                 # because on miss a lease empty value is generated
-                raise MemcacheError("Unexpected response")
+                raise MemcacheError(f"Unexpected response: {result} for key {key}")
 
     # pyre-ignore[3]  Yeah, we return 'Any'
     def get(
@@ -229,7 +229,7 @@ class CachePool(BaseCachePool):
             elif isinstance(result, Miss):
                 results[key] = None
             else:
-                raise MemcacheError("Unexpected response")
+                raise MemcacheError(f"Unexpected response: {result} for key {key}")
         return results
 
     # pyre-ignore[3]  Yeah, we return 'Any'
@@ -267,7 +267,7 @@ class CachePool(BaseCachePool):
         elif isinstance(result, Miss):
             return None, None
         else:
-            raise MemcacheError("Unexpected response")
+            raise MemcacheError(f"Unexpected response: {result} for key {key}")
 
     def get_typed(
         self,
@@ -300,7 +300,7 @@ class CachePool(BaseCachePool):
 
         if not isinstance(value, cls):
             if error_on_type_mismatch:
-                raise ValueError(f"Expecting {cls} got {value}")
+                raise ValueError(f"Expecting {cls} got {value} for {key}")
             else:
                 value = None
         return value, cas_token

--- a/tests/cache_pools_test.py
+++ b/tests/cache_pools_test.py
@@ -119,7 +119,7 @@ def test_sharded_with_gutter_cache_pool(mocker: MockerFixture) -> None:
     connection_pool = cache_pool._get_pool(Key("foo"))
     assert isinstance(connection_pool, ConnectionPool)
     assert connection_pool.server == "ko2:11211"
-    assert connection_pool._pool.qsize() == 0
+    assert len(connection_pool._pool) == 0
     assert connection_pool.get_counters() == PoolCounters(
         available=0,
         active=0,
@@ -131,7 +131,7 @@ def test_sharded_with_gutter_cache_pool(mocker: MockerFixture) -> None:
     connection_pool = cache_pool._get_pool(Key("bar"))
     assert isinstance(connection_pool, ConnectionPool)
     assert connection_pool.server == "ok1:11211"
-    assert connection_pool._pool.qsize() == 2
+    assert len(connection_pool._pool) == 2
     assert connection_pool.get_counters() == PoolCounters(
         available=2,
         active=0,


### PR DESCRIPTION
## Motivation / Description
deque seems to work better with gevent, and doesn't
need monkey patching.

## Changes introduced
- Switch to deque
- Improved errors
