### PR TITLE
Fix reset buffer issues and cleanup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meta-memcache"
-version = "0.6.0"
+version = "0.7.0"
 description = "Modern, pure python, memcache client with support for new meta commands."
 license = "MIT"
 readme = "README.md"

--- a/src/meta_memcache/base/memcache_socket.py
+++ b/src/meta_memcache/base/memcache_socket.py
@@ -104,7 +104,11 @@ class MemcacheSocket:
         read = 0
         size = len(buffer)
         while read < size:
-            read += self._conn.recv_into(buffer[read:], size - read, socket.MSG_WAITALL)
+            chunk_size = self._conn.recv_into(
+                buffer[read:], size - read, socket.MSG_WAITALL
+            )
+            if chunk_size > 0:
+                read += chunk_size
         return read
 
     def _reset_buffer(self) -> None:

--- a/src/meta_memcache/protocol.py
+++ b/src/meta_memcache/protocol.py
@@ -6,7 +6,6 @@ ENDL = b"\r\n"
 NOOP: bytes = b"mn" + ENDL
 ENDL_LEN = 2
 SPACE: int = ord(" ")
-MIN_HEADER_SIZE = 4
 
 
 class Key(NamedTuple):


### PR DESCRIPTION
## Motivation / Description
We were resetting the buffer in too many places,
while keeping a memory view with a slice of the
data. This can cause the memory view to end
corrupted, and we change the underlying buffer
contents.

## Changes introduced
* Only reset buffer before any response processing, so
  no more risks of altering the memoryviews created
  during response processing.
* Cleanup get_value(), found a more elegant way of
  reading the response and avoid using recvmsg_into
  that is more complex, harder to mock in tests
  and harder to debug.
