### PR TITLE
Fix bool serialization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meta-memcache"
-version = "0.7.0"
+version = "0.8.0"
 description = "Modern, pure python, memcache client with support for new meta commands."
 license = "MIT"
 readme = "README.md"

--- a/src/meta_memcache/serializer.py
+++ b/src/meta_memcache/serializer.py
@@ -25,7 +25,7 @@ class MixedSerializer(BaseSerializer):
         if isinstance(value, bytes):
             data = value
             encoding_id = self.BINARY
-        elif isinstance(value, int):
+        elif isinstance(value, int) and not isinstance(value, bool):
             data = str(value).encode("ascii")
             encoding_id = self.INT
         elif isinstance(value, str):

--- a/tests/base/cache_pool_test.py
+++ b/tests/base/cache_pool_test.py
@@ -141,6 +141,17 @@ def test_set_cmd(
     memcache_socket.sendall.reset_mock()
     memcache_socket.get_response.reset_mock()
 
+    value = False  # Bools should be stored pickled
+    data = pickle.dumps(value, protocol=0)
+    cache_pool.set(key=Key("foo"), value=value, ttl=300)
+    memcache_socket.sendall.assert_called_once_with(
+        b"ms foo " + str(len(data)).encode() + b" T300 F1\r\n" + data + b"\r\n",
+        with_noop=False,
+    )
+    memcache_socket.get_response.assert_called_once_with()
+    memcache_socket.sendall.reset_mock()
+    memcache_socket.get_response.reset_mock()
+
     cache_pool.set(key=Key("foo"), value=b"123", ttl=300)
     memcache_socket.sendall.assert_called_once_with(
         b"ms foo 3 T300 F16\r\n123\r\n", with_noop=False


### PR DESCRIPTION
## Motivation / Description
Booleans in python are a subclass of int, so they were
incorrectly serialized.

## Changes introduced
- Add check for boolean type
