### PR TITLE
Wrap timeouts into a MemcacheServerError

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meta-memcache"
-version = "0.8.1"
+version = "0.8.2"
 description = "Modern, pure python, memcache client with support for new meta commands."
 license = "MIT"
 readme = "README.md"

--- a/src/meta_memcache/base/connection_pool.py
+++ b/src/meta_memcache/base/connection_pool.py
@@ -125,14 +125,14 @@ class ConnectionPool:
 
         try:
             yield conn
-        except Exception:
+        except Exception as e:
             # Errors, assume connection is in bad state
             _log.warning(
                 "Error during cache conn context (discarding connection)",
                 exc_info=True,
             )
             self._discard_connection(conn, error=True)
-            raise
+            raise MemcacheServerError(self.server, "Memcache error") from e
         else:
             if len(self._pool) < self._max_pool_size:
                 # If there is a race, the  deque might end with more than

--- a/src/meta_memcache/errors.py
+++ b/src/meta_memcache/errors.py
@@ -2,7 +2,7 @@ class MemcacheError(Exception):
     pass
 
 
-class MemcacheServerError(Exception):
+class MemcacheServerError(MemcacheError):
     def __init__(self, server: str, message: str) -> None:
         self.server = server
         super().__init__(message)


### PR DESCRIPTION
## Motivation / Description
Timeouts on the socket are not correctly wrapped as
MemcacheServerErrors, do they are not handled nicely.

## Changes introduced
- raise MemcacheServerError wrapping original exception
  during the connection context.
