### PR TITLE
♻️ refactor: move from `BaseWriteFailureTracker` to event `OnWriteFailure`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "python.testing.unittestEnabled": false,
+  "python.testing.pytestEnabled": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## v0.9.0
+
+### Breaking changes
+The `WriteFailureTracker` base class has been removed and replaced with the `WriteFailureEvent`.
+As a stop-gap, you can apply the following changes to your code:
+
+```diff
+from meta_memcache import BaseWriteFailureTracker, Key
+
+
+- class CacheFailureTracker(BaseWriteFailureTracker):
++ class CacheFailureTracker(object):
++    def __init__(self, pool: BaseCachePool)-> None:
++        self._pool = pool
++        self.start_tracking()
++
++    def start_tracking(self) -> None:
++        self._pool.on_write_failure += self.add_key
++
++    def stop_tracking(self) -> None:
++        self._pool.on_write_failure -= self.add_key
+
+    def add_key(self, key: Key) -> None:
+        pass
+```
+
+Please note that any existing classes that implement `WriteFailureTracker` should be removed
+and the event based solution be properly implemented.

--- a/README.md
+++ b/README.md
@@ -380,12 +380,11 @@ a few classes implement the pool-level semantics:
   'gutter' pool, with TTLs overriden and lowered on the fly, so they provide
   some level of caching instead of hitting the backend for each request.
 
-These pools also provide a write failure tracker event, useful if you are
-serious about cache consistency. If you have transient network issues, some
-writes might fail, and if the server comes back without being restarted or the
-cache flushed, the data will be stale. This allows for failed writes to be
-collected and logged. Affected keys can then be invalidated later and eventual
-cache consistency guaranteed.
+These pools also provide an option to register a callback for write failure events. This might be useful
+if you are serious about cache consistency. If you have transient network issues, some writes might fail,
+and if the server comes back without being restarted or the cache flushed, the data will be stale. The
+events allows for failed writes to be collected and logged. Affected keys can then be invalidated later
+and eventual cache consistency guaranteed.
 
 It should be trivial to implement your own cache pool if you need custom
 sharding, shadowing, pools that support live migrations, etc. Feel free to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meta-memcache"
-version = "0.8.2"
+version = "0.9.0"
 description = "Modern, pure python, memcache client with support for new meta commands."
 license = "MIT"
 readme = "README.md"

--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -1,6 +1,5 @@
 __version__ = "0.1.0"
 
-from meta_memcache.base.base_write_failure_tracker import BaseWriteFailureTracker
 from meta_memcache.base.cache_pool import CachePool, SetMode
 from meta_memcache.cache_pools import ShardedCachePool, ShardedWithGutterCachePool
 from meta_memcache.configuration import (
@@ -12,6 +11,7 @@ from meta_memcache.configuration import (
     socket_factory_builder,
 )
 from meta_memcache.errors import MemcacheError, MemcacheServerError
+from meta_memcache.events.write_failure_event import WriteFailureEvent
 from meta_memcache.protocol import (
     Conflict,
     Flag,

--- a/src/meta_memcache/base/base_cache_pool.py
+++ b/src/meta_memcache/base/base_cache_pool.py
@@ -5,10 +5,10 @@ from collections import defaultdict
 from typing import Any, Callable, DefaultDict, Dict, Final, List, Optional, Set, Tuple
 
 from meta_memcache.base.base_serializer import BaseSerializer
-from meta_memcache.base.base_write_failure_tracker import BaseWriteFailureTracker
 from meta_memcache.base.connection_pool import ConnectionPool
 from meta_memcache.base.memcache_socket import MemcacheSocket
 from meta_memcache.errors import MemcacheError, MemcacheServerError
+from meta_memcache.events.write_failure_event import WriteFailureEvent
 from meta_memcache.protocol import (
     ENDL,
     Conflict,
@@ -37,11 +37,10 @@ class BaseCachePool(ABC):
         self,
         serializer: BaseSerializer,
         binary_key_encoding_fn: Callable[[Key], bytes],
-        write_failure_tracker: Optional[BaseWriteFailureTracker] = None,
     ) -> None:
         self._serializer = serializer
         self._binary_key_encoding_fn = binary_key_encoding_fn
-        self._write_failure_tracker: Final = write_failure_tracker
+        self.OnWriteFailure: Final = WriteFailureEvent()
 
     @abstractmethod
     def _get_pool(self, key: Key) -> ConnectionPool:
@@ -111,9 +110,8 @@ class BaseCachePool(ABC):
                 )
                 return self._conn_recv_response(conn, flags=flags)
         except MemcacheServerError:
-            if self._write_failure_tracker:
-                if command in (MetaCommand.META_DELETE, MetaCommand.META_SET):
-                    self._write_failure_tracker.add_key(key)
+            if command in (MetaCommand.META_DELETE, MetaCommand.META_SET):
+                self.OnWriteFailure(key)
             raise
 
     def _exec_multi(
@@ -152,12 +150,12 @@ class BaseCachePool(ABC):
                     for key in pool_keys:
                         results[key] = self._conn_recv_response(conn, flags=flags)
         except MemcacheServerError:
-            if self._write_failure_tracker and command in (
+            if command in (
                 MetaCommand.META_DELETE,
                 MetaCommand.META_SET,
             ):
-                for k in keys:
-                    self._write_failure_tracker.add_key(k)
+                for key in keys:
+                    self.OnWriteFailure(key)
             raise
         return results
 

--- a/src/meta_memcache/base/base_cache_pool.py
+++ b/src/meta_memcache/base/base_cache_pool.py
@@ -40,7 +40,7 @@ class BaseCachePool(ABC):
     ) -> None:
         self._serializer = serializer
         self._binary_key_encoding_fn = binary_key_encoding_fn
-        self.OnWriteFailure: Final = WriteFailureEvent()
+        self.on_write_failure: Final = WriteFailureEvent()
 
     @abstractmethod
     def _get_pool(self, key: Key) -> ConnectionPool:
@@ -111,7 +111,7 @@ class BaseCachePool(ABC):
                 return self._conn_recv_response(conn, flags=flags)
         except MemcacheServerError:
             if command in (MetaCommand.META_DELETE, MetaCommand.META_SET):
-                self.OnWriteFailure(key)
+                self.on_write_failure(key)
             raise
 
     def _exec_multi(
@@ -155,7 +155,7 @@ class BaseCachePool(ABC):
                 MetaCommand.META_SET,
             ):
                 for key in keys:
-                    self.OnWriteFailure(key)
+                    self.on_write_failure(key)
             raise
         return results
 

--- a/src/meta_memcache/base/base_write_failure_tracker.py
+++ b/src/meta_memcache/base/base_write_failure_tracker.py
@@ -1,9 +1,0 @@
-from abc import ABC, abstractmethod
-
-from meta_memcache.protocol import Key
-
-
-class BaseWriteFailureTracker(ABC):
-    @abstractmethod
-    def add_key(self, key: Key) -> None:
-        ...

--- a/src/meta_memcache/events/__init__.py
+++ b/src/meta_memcache/events/__init__.py
@@ -1,0 +1,1 @@
+"""meta_memcache.events"""

--- a/src/meta_memcache/events/write_failure_event.py
+++ b/src/meta_memcache/events/write_failure_event.py
@@ -5,16 +5,16 @@ from meta_memcache.protocol import Key
 
 class WriteFailureEvent(object):
     def __init__(self) -> None:
-        self.__eventhandlers: List[Callable[[Key], None]] = []
+        self._eventhandlers: List[Callable[[Key], None]] = []
 
     def __iadd__(self, handler: Callable[[Key], None]) -> "WriteFailureEvent":
-        self.__eventhandlers.append(handler)
+        self._eventhandlers.append(handler)
         return self
 
     def __isub__(self, handler: Callable[[Key], None]) -> "WriteFailureEvent":
-        self.__eventhandlers.remove(handler)
+        self._eventhandlers.remove(handler)
         return self
 
     def __call__(self, key: Key) -> None:
-        for eventhandler in self.__eventhandlers:
+        for eventhandler in self._eventhandlers:
             eventhandler(key)

--- a/src/meta_memcache/events/write_failure_event.py
+++ b/src/meta_memcache/events/write_failure_event.py
@@ -1,0 +1,20 @@
+from typing import Callable, List
+
+from meta_memcache.protocol import Key
+
+
+class WriteFailureEvent(object):
+    def __init__(self) -> None:
+        self.__eventhandlers: List[Callable[[Key], None]] = []
+
+    def __iadd__(self, handler: Callable[[Key], None]) -> "WriteFailureEvent":
+        self.__eventhandlers.append(handler)
+        return self
+
+    def __isub__(self, handler: Callable[[Key], None]) -> "WriteFailureEvent":
+        self.__eventhandlers.remove(handler)
+        return self
+
+    def __call__(self, key: Key) -> None:
+        for eventhandler in self.__eventhandlers:
+            eventhandler(key)

--- a/tests/base/cache_pool_test.py
+++ b/tests/base/cache_pool_test.py
@@ -806,7 +806,7 @@ def test_on_write_failure(
 ) -> None:
     failures_tracked: list[Key] = []
     on_failure: Callable[[Key], None] = lambda key: failures_tracked.append(key)
-    cache_pool.OnWriteFailure += on_failure
+    cache_pool.on_write_failure += on_failure
 
     cache_pool.connection_pool.get_connection.side_effect = MemcacheServerError(
         server="broken:11211", message="uh-oh"


### PR DESCRIPTION
## Summary
This PR refactors the write failure tracking to be event-based vs an abstract class based.

## Details
After using this feature a bit we noticed some shortcomings with the previous implementation. This change switches to an event based system that allows for as many consumers as need to be notified/take action when a write failure occurs, and reducing some of the complexity of implementing a tracker class.

This does contain a breaking change as it removes the `BaseWriteFailureTracker` class, but the following code can be used to back-port any existing implementations.

```diff
from meta_memcache import BaseWriteFailureTracker, Key


- class CacheFailureTracker(BaseWriteFailureTracker):
+ class CacheFailureTracker(object):
+    def __init__(self, pool: BaseCachePool)-> None:
+        self._pool = pool
+        self._pool.on_write_failure += self.add_key
+
+    def __del__(self) -> None:
+        self._pool.on_write_failure -= self.add_key

    def add_key(self, key: Key) -> None:
        pass
```