### PR TITLE
🔖 chore(ver): bump to 0.9.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meta-memcache"
-version = "0.9.0"
+version = "0.9.1"
 description = "Modern, pure python, memcache client with support for new meta commands."
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
This just bumps the version as 0.9.0 was accidentally released when setting up ci/cd