### PR TITLE
♻️ refactor: remove Final from event so that new handlers can be added or removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.9.2
+### Fixed
+* `on_write_failure` event handler now can be subscribed/unsubscribed to.
+
 ## v0.9.1
 * Error logging fixes
 

--- a/src/meta_memcache/base/base_cache_pool.py
+++ b/src/meta_memcache/base/base_cache_pool.py
@@ -2,7 +2,7 @@ import base64
 import logging
 from abc import ABC, abstractmethod
 from collections import defaultdict
-from typing import Any, Callable, DefaultDict, Dict, Final, List, Optional, Set, Tuple
+from typing import Any, Callable, DefaultDict, Dict, List, Optional, Set, Tuple
 
 from meta_memcache.base.base_serializer import BaseSerializer
 from meta_memcache.base.connection_pool import ConnectionPool

--- a/src/meta_memcache/base/base_cache_pool.py
+++ b/src/meta_memcache/base/base_cache_pool.py
@@ -40,7 +40,7 @@ class BaseCachePool(ABC):
     ) -> None:
         self._serializer = serializer
         self._binary_key_encoding_fn = binary_key_encoding_fn
-        self.on_write_failure: Final = WriteFailureEvent()
+        self.on_write_failure = WriteFailureEvent()
 
     @abstractmethod
     def _get_pool(self, key: Key) -> ConnectionPool:


### PR DESCRIPTION
An assumption was made to add `Final` to the `on_write_failure` event in the `BaseCachePool`. This assumption was incorrect and prevents type checks from passing when registering/removing an event handler.
