### PR TITLE
Request keys in responses

### DIFF
--- a/src/meta_memcache/base/cache_pool.py
+++ b/src/meta_memcache/base/cache_pool.py
@@ -131,6 +131,7 @@ class CachePool(BaseCachePool):
             Flag.RETURN_CAS_TOKEN,
             Flag.RETURN_LAST_ACCESS,
             Flag.RETURN_FETCHED,
+            Flag.RETURN_KEY,
         }
         int_flags = {
             IntFlag.MISS_LEASE_TTL: lease_policy.ttl,
@@ -201,6 +202,7 @@ class CachePool(BaseCachePool):
             Flag.RETURN_CLIENT_FLAG,
             Flag.RETURN_LAST_ACCESS,
             Flag.RETURN_FETCHED,
+            Flag.RETURN_KEY,
         }
         int_flags = {}
         if recache_policy:
@@ -242,6 +244,7 @@ class CachePool(BaseCachePool):
             Flag.RETURN_CAS_TOKEN,
             Flag.RETURN_LAST_ACCESS,
             Flag.RETURN_FETCHED,
+            Flag.RETURN_KEY,
         }
         int_flags = {}
         if recache_policy:

--- a/src/meta_memcache/cache_pools.py
+++ b/src/meta_memcache/cache_pools.py
@@ -174,4 +174,4 @@ class ShardedWithGutterCachePool(ShardedCachePool):
                     int_flags=int_flags,
                     token_flags=token_flags,
                 )
-                return self._conn_recv_response(c, flags=flags)
+                return self._conn_recv_response(c, key=key, flags=flags)

--- a/tests/base/cache_pool_test.py
+++ b/tests/base/cache_pool_test.py
@@ -488,7 +488,7 @@ def test_get_other(memcache_socket: MemcacheSocket, cache_pool: FakeCachePool) -
         cache_pool.get(
             key=Key("foo"),
         )
-        raise AssertionError("Should not be reached")
+        pytest.fail("Should not be reached")
     except MemcacheError as e:
         assert "Unexpected response" in str(e)
 
@@ -516,7 +516,7 @@ def test_value_wrong_type(
 
     try:
         cache_pool.get_cas_typed(key=Key("foo"), cls=Bar, error_on_type_mismatch=True)
-        raise AssertionError("Should not be reached")
+        pytest.fail("Should not be reached")
     except ValueError as e:
         assert "Expecting <class 'tests.base.cache_pool_test.Bar'> got Foo" in str(e)
 
@@ -525,7 +525,7 @@ def test_value_wrong_type(
 
     try:
         cache_pool.get_typed(key=Key("foo"), cls=Bar, error_on_type_mismatch=True)
-        raise AssertionError("Should not be reached")
+        pytest.fail("Should not be reached")
     except ValueError as e:
         assert "Expecting <class 'tests.base.cache_pool_test.Bar'> got Foo" in str(e)
 
@@ -542,7 +542,7 @@ def test_value_wrong_key_result(
     )
     try:
         cache_pool.get(key=Key("foo"))
-        raise AssertionError("Should not be reached")
+        pytest.fail("Should not be reached")
     except MemcacheError as e:
         assert "Expecting value for key" in str(e)
 
@@ -813,7 +813,7 @@ def test_get_or_lease_errors(
             touch_ttl=300,
             recache_policy=RecachePolicy(ttl=60),
         )
-        raise AssertionError("Should not be reached")
+        pytest.fail("Should not be reached")
     except MemcacheError:
         pass
     memcache_socket.sendall.assert_called_once_with(
@@ -828,7 +828,7 @@ def test_get_or_lease_errors(
             touch_ttl=300,
             recache_policy=RecachePolicy(ttl=60),
         )
-        raise AssertionError("Should not be reached")
+        pytest.fail("Should not be reached")
     except ValueError as e:
         assert "Wrong lease_policy: miss_retries needs to be greater than 0" in str(e)
 
@@ -846,7 +846,7 @@ def test_on_write_failure(
     )
     try:
         cache_pool.get(key=Key("foo"))
-        raise AssertionError("Should not be reached")
+        pytest.fail("Should not be reached")
     except MemcacheServerError as e:
         assert "uh-oh" in str(e)
     assert len(failures_tracked) == 0
@@ -854,7 +854,7 @@ def test_on_write_failure(
 
     try:
         cache_pool.delete(key=Key("foo"))
-        raise AssertionError("Should not be reached")
+        pytest.fail("Should not be reached")
     except MemcacheServerError as e:
         assert "uh-oh" in str(e)
     assert len(failures_tracked) == 1
@@ -863,7 +863,7 @@ def test_on_write_failure(
 
     try:
         cache_pool.set(key=Key("foo"), value=1, ttl=10)
-        raise AssertionError("Should not be reached")
+        pytest.fail("Should not be reached")
     except MemcacheServerError as e:
         assert "uh-oh" in str(e)
     assert len(failures_tracked) == 1


### PR DESCRIPTION
## Motivation / Description
To help debugging possible issues with connections memcache
protocol supports requesting the key in the response, so
we can validate and error properly if the value is not
the one we expect.

## Changes introduced
- Request key in meta gets
- Validate key on value responses.
