### PR TITLE
Add custom error subclass for when a server is marked down.

### DIFF
--- a/src/meta_memcache/base/base_cache_pool.py
+++ b/src/meta_memcache/base/base_cache_pool.py
@@ -303,7 +303,6 @@ class BaseCachePool(ABC):
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
     ) -> Dict[Key, ReadResponse]:
-
         results: Dict[Key, ReadResponse] = {}
         for key, result in self._exec_multi(
             command=MetaCommand.META_GET,

--- a/src/meta_memcache/base/connection_pool.py
+++ b/src/meta_memcache/base/connection_pool.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from typing import Callable, Deque, Generator, NamedTuple, Optional
 
 from meta_memcache.base.memcache_socket import MemcacheSocket
-from meta_memcache.errors import MemcacheServerError
+from meta_memcache.errors import MemcacheServerError, ServerMarkedDownError
 from meta_memcache.protocol import ServerVersion
 from meta_memcache.settings import DEFAULT_MARK_DOWN_PERIOD_S, DEFAULT_READ_BUFFER_SIZE
 
@@ -83,7 +83,7 @@ class ConnectionPool:
     def _create_connection(self) -> MemcacheSocket:
         if marked_down_until := self._marked_down_until:
             if time.time() < marked_down_until:
-                raise MemcacheServerError(
+                raise ServerMarkedDownError(
                     self.server, f"Server marked down: {self.server}"
                 )
             self._marked_down_until = None
@@ -97,7 +97,7 @@ class ConnectionPool:
             )
             self._errors = next(self._errors_counter)
             self._marked_down_until = time.time() + self._mark_down_period_s
-            raise MemcacheServerError(
+            raise ServerMarkedDownError(
                 self.server, f"Server marked down: {self.server}"
             ) from e
 

--- a/src/meta_memcache/errors.py
+++ b/src/meta_memcache/errors.py
@@ -6,3 +6,7 @@ class MemcacheServerError(MemcacheError):
     def __init__(self, server: str, message: str) -> None:
         self.server = server
         super().__init__(message)
+
+
+class ServerMarkedDownError(MemcacheServerError):
+    ...


### PR DESCRIPTION
We want to handle these errors differently - having a specific subclass will make filtering them cleaner than having to use the error message.