### PR TITLE
Use TypeVars for from_server* factory methods

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meta-memcache"
-version = "0.9.4"
+version = "0.9.5"
 description = "Modern, pure python, memcache client with support for new meta commands."
 license = "MIT"
 readme = "README.md"

--- a/src/meta_memcache/base/base_cache_pool.py
+++ b/src/meta_memcache/base/base_cache_pool.py
@@ -303,7 +303,6 @@ class BaseCachePool(ABC):
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
     ) -> Dict[Key, ReadResponse]:
-
         results: Dict[Key, ReadResponse] = {}
         for key, result in self._exec_multi(
             command=MetaCommand.META_GET,

--- a/src/meta_memcache/cache_pools.py
+++ b/src/meta_memcache/cache_pools.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, Iterable, List, Optional, Set
+from typing import Callable, Dict, Iterable, List, Optional, Set, Type, TypeVar
 
 from uhashring import HashRing  # type: ignore
 
@@ -38,6 +38,9 @@ class MultiServerCachePool(CachePool):
         }
 
 
+ShardedCachePoolT = TypeVar("ShardedCachePoolT", bound="ShardedCachePool")
+
+
 class ShardedCachePool(MultiServerCachePool):
     def __init__(
         self,
@@ -62,13 +65,13 @@ class ShardedCachePool(MultiServerCachePool):
 
     @classmethod
     def from_server_addresses(
-        cls,
+        cls: Type[ShardedCachePoolT],
         servers: Iterable[ServerAddress],
         connection_pool_factory_fn: Callable[[ServerAddress], ConnectionPool],
         serializer: Optional[BaseSerializer] = None,
         binary_key_encoding_fn: Callable[[Key], bytes] = default_binary_key_encoding,
         raise_on_server_error: bool = True,
-    ) -> "ShardedCachePool":
+    ) -> ShardedCachePoolT:
         server_pool: Dict[ServerAddress, ConnectionPool] = {
             server: connection_pool_factory_fn(server) for server in servers
         }
@@ -78,6 +81,11 @@ class ShardedCachePool(MultiServerCachePool):
             binary_key_encoding_fn=binary_key_encoding_fn,
             raise_on_server_error=raise_on_server_error,
         )
+
+
+ShardedWithGutterCachePoolT = TypeVar(
+    "ShardedWithGutterCachePoolT", bound="ShardedWithGutterCachePool"
+)
 
 
 class ShardedWithGutterCachePool(ShardedCachePool):
@@ -105,7 +113,7 @@ class ShardedWithGutterCachePool(ShardedCachePool):
 
     @classmethod
     def from_server_with_gutter_server_addresses(
-        cls,
+        cls: Type[ShardedWithGutterCachePoolT],
         servers: Iterable[ServerAddress],
         gutter_servers: Iterable[ServerAddress],
         gutter_ttl: int,
@@ -113,7 +121,7 @@ class ShardedWithGutterCachePool(ShardedCachePool):
         serializer: Optional[BaseSerializer] = None,
         binary_key_encoding_fn: Callable[[Key], bytes] = default_binary_key_encoding,
         raise_on_server_error: bool = True,
-    ) -> "ShardedWithGutterCachePool":
+    ) -> ShardedWithGutterCachePoolT:
         server_pool: Dict[ServerAddress, ConnectionPool] = {
             server: connection_pool_factory_fn(server) for server in servers
         }


### PR DESCRIPTION
## Motivation / Description
Using typevars allows child classes to work and get
the right type hinting.

Before if you wanted to extend `ShardedCachePool` and use `from_server_addresses`
the type hints on that method will suggest the class is the original class instead of the
new you are just implementing.
