### PR TITLE
[Refactor] Add Protocol for cache commands

### DIFF
--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -1,6 +1,6 @@
 __version__ = "0.1.0"
 
-from meta_memcache.base.cache_pool import CachePool, SetMode
+from meta_memcache.base.cache_pool import CachePool
 from meta_memcache.cache_pools import ShardedCachePool, ShardedWithGutterCachePool
 from meta_memcache.configuration import (
     LeasePolicy,
@@ -20,6 +20,7 @@ from meta_memcache.protocol import (
     Miss,
     NotStored,
     ServerVersion,
+    SetMode,
     Success,
     TokenFlag,
     Value,

--- a/src/meta_memcache/base/cache_pool.py
+++ b/src/meta_memcache/base/cache_pool.py
@@ -1,21 +1,21 @@
 import time
-from enum import Enum
 from typing import Any, Dict, Iterable, Optional, Set, Tuple, Type, TypeVar, Union
 
 from meta_memcache.base.base_cache_pool import BaseCachePool
 from meta_memcache.configuration import LeasePolicy, RecachePolicy, StalePolicy
 from meta_memcache.errors import MemcacheError
-from meta_memcache.protocol import Flag, IntFlag, Key, Miss, Success, TokenFlag, Value
+from meta_memcache.protocol import (
+    Flag,
+    IntFlag,
+    Key,
+    Miss,
+    SetMode,
+    Success,
+    TokenFlag,
+    Value,
+)
 
 T = TypeVar("T")
-
-
-class SetMode(Enum):
-    SET = b"S"  # Default
-    ADD = b"E"  # LRU bump and return NS if item exists. Else add.
-    APPEND = b"A"  # If item exists, append the new value to its data.
-    PREPEND = b"P"  # If item exists, prepend the new value to its data.
-    REPLACE = b"R"  # Set only if item already exists.
 
 
 class CachePool(BaseCachePool):

--- a/src/meta_memcache/interfaces/commands.py
+++ b/src/meta_memcache/interfaces/commands.py
@@ -1,0 +1,8 @@
+from typing import Protocol
+
+from meta_memcache.interfaces.high_level_commands import HighLevelCommandsProtocol
+from meta_memcache.interfaces.meta_commands import MetaCommandsProtocol
+
+
+class CommandsProtocol(HighLevelCommandsProtocol, MetaCommandsProtocol, Protocol):
+    pass

--- a/src/meta_memcache/interfaces/high_level_commands.py
+++ b/src/meta_memcache/interfaces/high_level_commands.py
@@ -1,0 +1,160 @@
+from typing import Any, Dict, Iterable, Optional, Protocol, Tuple, Type, TypeVar, Union
+
+from meta_memcache.configuration import LeasePolicy, RecachePolicy, StalePolicy
+from meta_memcache.protocol import Key, SetMode, Value
+
+T = TypeVar("T")
+
+
+class HighLevelCommandsProtocol(Protocol):
+    def set(
+        self,
+        key: Union[Key, str],
+        value: Any,
+        ttl: int,
+        no_reply: bool = False,
+        cas_token: Optional[int] = None,
+        stale_policy: Optional[StalePolicy] = None,
+        set_mode: SetMode = SetMode.SET,
+    ) -> bool:
+        ...
+
+    def delete(
+        self,
+        key: Union[Key, str],
+        cas_token: Optional[int] = None,
+        no_reply: bool = False,
+        stale_policy: Optional[StalePolicy] = None,
+    ) -> bool:
+        ...
+
+    def touch(
+        self,
+        key: Union[Key, str],
+        ttl: int,
+        no_reply: bool = False,
+    ) -> bool:
+        ...
+
+    def get_or_lease(
+        self,
+        key: Union[Key, str],
+        lease_policy: LeasePolicy,
+        touch_ttl: Optional[int] = None,
+        recache_policy: Optional[RecachePolicy] = None,
+    ) -> Optional[Any]:
+        ...
+
+    def get_or_lease_cas(
+        self,
+        key: Union[Key, str],
+        lease_policy: LeasePolicy,
+        touch_ttl: Optional[int] = None,
+        recache_policy: Optional[RecachePolicy] = None,
+    ) -> Tuple[Optional[Any], Optional[int]]:
+        ...
+
+    def get(
+        self,
+        key: Union[Key, str],
+        touch_ttl: Optional[int] = None,
+        recache_policy: Optional[RecachePolicy] = None,
+    ) -> Optional[Any]:
+        ...
+
+    def multi_get(
+        self,
+        keys: Iterable[Union[Key, str]],
+        touch_ttl: Optional[int] = None,
+        recache_policy: Optional[RecachePolicy] = None,
+    ) -> Dict[Key, Optional[Any]]:
+        ...
+
+    def _multi_get(
+        self,
+        keys: Iterable[Union[Key, str]],
+        touch_ttl: Optional[int] = None,
+        recache_policy: Optional[RecachePolicy] = None,
+        return_cas_token: bool = False,
+    ) -> Dict[Key, Optional[Value]]:
+        ...
+
+    def get_cas(
+        self,
+        key: Union[Key, str],
+        touch_ttl: Optional[int] = None,
+        recache_policy: Optional[RecachePolicy] = None,
+    ) -> Tuple[Optional[Any], Optional[int]]:
+        ...
+
+    def _get(
+        self,
+        key: Union[Key, str],
+        touch_ttl: Optional[int] = None,
+        lease_policy: Optional[LeasePolicy] = None,
+        recache_policy: Optional[RecachePolicy] = None,
+        return_cas_token: bool = False,
+    ) -> Optional[Value]:
+        ...
+
+    def get_typed(
+        self,
+        key: Union[Key, str],
+        cls: Type[T],
+        touch_ttl: Optional[int] = None,
+        recache_policy: Optional[RecachePolicy] = None,
+        error_on_type_mismatch: bool = False,
+    ) -> Optional[T]:
+        ...
+
+    def get_cas_typed(
+        self,
+        key: Union[Key, str],
+        cls: Type[T],
+        touch_ttl: Optional[int] = None,
+        recache_policy: Optional[RecachePolicy] = None,
+        error_on_type_mismatch: bool = False,
+    ) -> Tuple[Optional[T], Optional[int]]:
+        ...
+
+    def delta(
+        self,
+        key: Union[Key, str],
+        delta: int,
+        refresh_ttl: Optional[int] = None,
+        no_reply: bool = False,
+        cas_token: Optional[int] = None,
+    ) -> bool:
+        ...
+
+    def delta_initialize(
+        self,
+        key: Union[Key, str],
+        delta: int,
+        initial_value: int,
+        initial_ttl: int,
+        refresh_ttl: Optional[int] = None,
+        no_reply: bool = False,
+        cas_token: Optional[int] = None,
+    ) -> bool:
+        ...
+
+    def delta_and_get(
+        self,
+        key: Union[Key, str],
+        delta: int,
+        refresh_ttl: Optional[int] = None,
+        cas_token: Optional[int] = None,
+    ) -> Optional[int]:
+        ...
+
+    def delta_initialize_and_get(
+        self,
+        key: Union[Key, str],
+        delta: int,
+        initial_value: int,
+        initial_ttl: int,
+        refresh_ttl: Optional[int] = None,
+        cas_token: Optional[int] = None,
+    ) -> Optional[int]:
+        ...

--- a/src/meta_memcache/interfaces/meta_commands.py
+++ b/src/meta_memcache/interfaces/meta_commands.py
@@ -1,0 +1,60 @@
+from typing import Protocol
+from typing import Any, Dict, List, Optional, Set
+
+from meta_memcache.protocol import (
+    Flag,
+    IntFlag,
+    Key,
+    ReadResponse,
+    TokenFlag,
+    WriteResponse,
+)
+
+
+class MetaCommandsProtocol(Protocol):
+    def meta_multiget(
+        self,
+        keys: List[Key],
+        flags: Optional[Set[Flag]] = None,
+        int_flags: Optional[Dict[IntFlag, int]] = None,
+        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+    ) -> Dict[Key, ReadResponse]:
+        ...
+
+    def meta_get(
+        self,
+        key: Key,
+        flags: Optional[Set[Flag]] = None,
+        int_flags: Optional[Dict[IntFlag, int]] = None,
+        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+    ) -> ReadResponse:
+        ...
+
+    def meta_set(
+        self,
+        key: Key,
+        value: Any,
+        ttl: int,
+        flags: Optional[Set[Flag]] = None,
+        int_flags: Optional[Dict[IntFlag, int]] = None,
+        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+    ) -> WriteResponse:
+        ...
+
+    def meta_delete(
+        self,
+        key: Key,
+        flags: Optional[Set[Flag]] = None,
+        int_flags: Optional[Dict[IntFlag, int]] = None,
+        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+    ) -> WriteResponse:
+        ...
+
+    def meta_arithmetic(
+        self,
+        key: Key,
+        flags: Optional[Set[Flag]] = None,
+        int_flags: Optional[Dict[IntFlag, int]] = None,
+        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+    ) -> WriteResponse:
+        ...

--- a/src/meta_memcache/protocol.py
+++ b/src/meta_memcache/protocol.py
@@ -21,6 +21,14 @@ class MetaCommand(Enum):
     META_ARITHMETIC = b"ma"  # Meta Arithmetic
 
 
+class SetMode(Enum):
+    SET = b"S"  # Default
+    ADD = b"E"  # Add if item does NOT EXIST, else LRU bump and return NS
+    APPEND = b"A"  # If item exists, append the new value to its data.
+    PREPEND = b"P"  # If item exists, prepend the new value to its data.
+    REPLACE = b"R"  # Set only if item already exists.
+
+
 class Flag(Enum):
     BINARY = b"b"
     NOREPLY = b"q"


### PR DESCRIPTION
## Motivation / Description
Cache pools often need a lot of tweaking and changes. The
application code should only rely on the high-level memcache
protocol, instead of concrete class instances.

This will give us more flexibility to override and implement
different pool behaviors.

## Changes introduced
- Create interfaces for meta commands, high level commands and
  for both.
