### PR TITLE
Add Migrating Cache Pool

### DIFF
--- a/src/meta_memcache/configuration.py
+++ b/src/meta_memcache/configuration.py
@@ -188,7 +188,7 @@ class MigrationMode(IntEnum):
     POPULATE_WRITES_AND_READS_1PCT = 3
 
     # Use the origin cache pool, but replicate writes
-    # and 1% of reads to the destination cache pool
+    # and 10% of reads to the destination cache pool
     POPULATE_WRITES_AND_READS_10PCT = 4
 
     # Use the destination cache pool, but update the

--- a/src/meta_memcache/configuration.py
+++ b/src/meta_memcache/configuration.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import socket
+from enum import IntEnum
 from typing import Callable, Dict, Iterable, NamedTuple, Optional, Tuple
 
 from meta_memcache.connection.pool import ConnectionPool
@@ -167,3 +168,33 @@ def default_key_encoder(key: Key) -> Tuple[bytes, bool]:
         raise ValueError(f"Invalid key {key}")
     else:
         return key.key.encode("ascii"), False
+
+
+class MigrationMode(IntEnum):
+    """
+    Describes how to migrate data from one cache to another.
+    """
+
+    # Only use the origin cache pool. The destination
+    # cache pool will not get changes, should be empty.
+    ONLY_ORIGIN = 1
+
+    # Use the origin cache pool, but replicate writes
+    # to the destination cache pool
+    POPULATE_WRITES = 2
+
+    # Use the origin cache pool, but replicate writes
+    # and 1% of reads to the destination cache pool
+    POPULATE_WRITES_AND_READS_1PCT = 3
+
+    # Use the origin cache pool, but replicate writes
+    # and 1% of reads to the destination cache pool
+    POPULATE_WRITES_AND_READS_10PCT = 4
+
+    # Use the destination cache pool, but update the
+    # origin cache pool with writes
+    USE_DESTINATION_UPDATE_ORIGIN = 5
+
+    # Only use the destination cache pool, the origin
+    # cache pool will become stale
+    ONLY_DESTINATION = 6

--- a/src/meta_memcache/extras/migrating_cache_client.py
+++ b/src/meta_memcache/extras/migrating_cache_client.py
@@ -1,0 +1,301 @@
+import random
+import time
+from typing import Any, Dict, List, Optional, Set, Union
+
+from meta_memcache.commands.high_level_commands import HighLevelCommandsMixin
+from meta_memcache.configuration import MigrationMode, ServerAddress
+from meta_memcache.connection.pool import PoolCounters
+from meta_memcache.events.write_failure_event import WriteFailureEvent
+from meta_memcache.interfaces.cache_api import CacheApi
+from meta_memcache.protocol import (
+    Flag,
+    IntFlag,
+    Key,
+    ReadResponse,
+    SetMode,
+    TokenFlag,
+    Value,
+    WriteResponse,
+)
+
+
+class MigratingCacheClient(HighLevelCommandsMixin):
+    """
+    Cache pool that migrates data from one cache to another.
+
+    This is useful for testing read paths while the write
+    path (and thus the invalidations and cache updates)
+    are nor enabled, so expiring data is the only way
+    to keep cache consistent.
+
+    migration_mode_config controls how the pools are used.
+    See MigrationMode for description on the different modes.
+    This can be just a single MigrationMode or a dict of
+    MigrationMode to unix timestamp, controlling when each
+    of the modes should be used.
+    For example
+    {
+        MigrationMode.POPULATE_WRITES: 10,
+        MigrationMode.USE_DESTINATION_UPDATE_ORIGIN: 20,
+        MigrationMode.ONLY_DESTINATION: 30
+    }
+    will use the default, ONLY_ORIGIN, until time=10,
+    then POPULATE_WRITES until time=20 and then ONLY_DESTINATION
+    after time=30.
+    """
+
+    def __init__(
+        self,
+        origin_client: CacheApi,
+        destination_client: CacheApi,
+        migration_mode_config: Union[MigrationMode, Dict[MigrationMode, int]],
+        default_read_backfill_ttl: int = 3600,
+    ) -> None:
+        # Share the WriteFailureEvent across all clients
+        self.on_write_failure = WriteFailureEvent()
+        origin_client.on_write_failure = self.on_write_failure
+        destination_client.on_write_failure = self.on_write_failure
+
+        self._origin_client: CacheApi = origin_client
+        self._destination_client: CacheApi = destination_client
+        self._migration_mode_config = migration_mode_config
+        self._default_read_backfill_ttl = default_read_backfill_ttl
+
+    def get_migration_mode(self) -> MigrationMode:
+        if isinstance(self._migration_mode_config, MigrationMode):
+            return self._migration_mode_config
+        else:
+            now = time.time()
+            current_until = -1
+            current_mode = MigrationMode.ONLY_ORIGIN
+            for mode, until in self._migration_mode_config.items():
+                if now >= until and until > current_until:
+                    current_until = until
+                    current_mode = mode
+            return current_mode
+
+    def _get_value_ttl(self, value: Value) -> int:
+        ttl = value.int_flags.get(IntFlag.TTL, self._default_read_backfill_ttl)
+        if ttl < 0:
+            # TTL for items marked to store forvered is returned as -1
+            ttl = 0
+        return ttl
+
+    def _should_populate_read(self, migration_mode: MigrationMode) -> bool:
+        pct = (
+            1 if migration_mode == MigrationMode.POPULATE_WRITES_AND_READS_1PCT else 10
+        )
+        return (random.getrandbits(10) % 100) < pct
+
+    def meta_multiget(
+        self,
+        keys: List[Key],
+        flags: Optional[Set[Flag]] = None,
+        int_flags: Optional[Dict[IntFlag, int]] = None,
+        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+    ) -> Dict[Key, ReadResponse]:
+        migration_mode = self.get_migration_mode()
+        if migration_mode >= MigrationMode.USE_DESTINATION_UPDATE_ORIGIN:
+            return self._destination_client.meta_multiget(
+                keys=keys,
+                flags=flags,
+                int_flags=int_flags,
+                token_flags=token_flags,
+            )
+        elif migration_mode in (
+            MigrationMode.POPULATE_WRITES_AND_READS_1PCT,
+            MigrationMode.POPULATE_WRITES_AND_READS_10PCT,
+        ):
+            results = self._origin_client.meta_multiget(
+                keys=keys,
+                flags=flags,
+                int_flags=int_flags,
+                token_flags=token_flags,
+            )
+            if self._should_populate_read(migration_mode):
+                for key, result in results.items():
+                    if isinstance(result, Value):
+                        self._destination_client.set(
+                            key=key,
+                            value=result.value,
+                            ttl=self._get_value_ttl(result),
+                            no_reply=True,
+                            set_mode=SetMode.ADD,
+                        )
+            return results
+        else:
+            return self._origin_client.meta_multiget(
+                keys=keys,
+                flags=flags,
+                int_flags=int_flags,
+                token_flags=token_flags,
+            )
+
+    def meta_get(
+        self,
+        key: Key,
+        flags: Optional[Set[Flag]] = None,
+        int_flags: Optional[Dict[IntFlag, int]] = None,
+        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+    ) -> ReadResponse:
+        migration_mode = self.get_migration_mode()
+        if migration_mode >= MigrationMode.USE_DESTINATION_UPDATE_ORIGIN:
+            return self._destination_client.meta_get(
+                key=key,
+                flags=flags,
+                int_flags=int_flags,
+                token_flags=token_flags,
+            )
+        elif migration_mode in (
+            MigrationMode.POPULATE_WRITES_AND_READS_1PCT,
+            MigrationMode.POPULATE_WRITES_AND_READS_10PCT,
+        ):
+            result = self._origin_client.meta_get(
+                key=key,
+                flags=flags,
+                int_flags=int_flags,
+                token_flags=token_flags,
+            )
+            if isinstance(result, Value) and self._should_populate_read(migration_mode):
+                self._destination_client.set(
+                    key=key,
+                    value=result.value,
+                    ttl=self._get_value_ttl(result),
+                    no_reply=True,
+                    set_mode=SetMode.ADD,
+                )
+            return result
+        else:
+            return self._origin_client.meta_get(
+                key=key,
+                flags=flags,
+                int_flags=int_flags,
+                token_flags=token_flags,
+            )
+
+    def meta_set(
+        self,
+        key: Key,
+        value: Any,
+        ttl: int,
+        flags: Optional[Set[Flag]] = None,
+        int_flags: Optional[Dict[IntFlag, int]] = None,
+        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+    ) -> WriteResponse:
+        origin_response = destination_response = None
+        migration_mode = self.get_migration_mode()
+        if migration_mode < MigrationMode.ONLY_DESTINATION:
+            origin_response = self._origin_client.meta_set(
+                key=key,
+                value=value,
+                ttl=ttl,
+                flags=flags,
+                int_flags=int_flags,
+                token_flags=token_flags,
+            )
+        if migration_mode > MigrationMode.ONLY_ORIGIN:
+            destination_response = self._destination_client.meta_set(
+                key=key,
+                value=value,
+                ttl=ttl,
+                flags=flags,
+                int_flags=int_flags,
+                token_flags=token_flags,
+            )
+        if migration_mode >= MigrationMode.USE_DESTINATION_UPDATE_ORIGIN:
+            assert destination_response is not None  # noqa: S101
+            return destination_response
+        else:
+            assert origin_response is not None  # noqa: S101
+            return origin_response
+
+    def meta_delete(
+        self,
+        key: Key,
+        flags: Optional[Set[Flag]] = None,
+        int_flags: Optional[Dict[IntFlag, int]] = None,
+        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+    ) -> WriteResponse:
+        origin_response = destination_response = None
+        migration_mode = self.get_migration_mode()
+        if migration_mode < MigrationMode.ONLY_DESTINATION:
+            origin_response = self._origin_client.meta_delete(
+                key=key,
+                flags=flags,
+                int_flags=int_flags,
+                token_flags=token_flags,
+            )
+        if migration_mode > MigrationMode.ONLY_ORIGIN:
+            destination_response = self._destination_client.meta_delete(
+                key=key,
+                flags=flags,
+                int_flags=int_flags,
+                token_flags=token_flags,
+            )
+        if migration_mode >= MigrationMode.USE_DESTINATION_UPDATE_ORIGIN:
+            assert destination_response is not None  # noqa: S101
+            return destination_response
+        else:
+            assert origin_response is not None  # noqa: S101
+            return origin_response
+
+    def meta_arithmetic(
+        self,
+        key: Key,
+        flags: Optional[Set[Flag]] = None,
+        int_flags: Optional[Dict[IntFlag, int]] = None,
+        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+    ) -> WriteResponse:
+        """
+        We can't reliably migrate cache data modified by meta-arithmetic,
+        since we may now know the value after the operation. Using memcache
+        for counters is only used as rough estimates, so we can just ignore
+        this for the migration.
+        """
+        migration_mode = self.get_migration_mode()
+        if migration_mode >= MigrationMode.USE_DESTINATION_UPDATE_ORIGIN:
+            return self._destination_client.meta_arithmetic(
+                key=key,
+                flags=flags,
+                int_flags=int_flags,
+                token_flags=token_flags,
+            )
+        else:
+            return self._origin_client.meta_arithmetic(
+                key=key,
+                flags=flags,
+                int_flags=int_flags,
+                token_flags=token_flags,
+            )
+
+    def touch(
+        self,
+        key: Union[Key, str],
+        ttl: int,
+        no_reply: bool = False,
+    ) -> bool:
+        """
+        This is a special kind of get that also updates the ttl of the key, and
+        it is used to ensure cache consistency, so we will send it to both clients.
+        """
+        origin_response = destination_response = None
+        migration_mode = self.get_migration_mode()
+        if migration_mode < MigrationMode.ONLY_DESTINATION:
+            origin_response = self._origin_client.touch(
+                key=key, ttl=ttl, no_reply=no_reply
+            )
+        if migration_mode > MigrationMode.ONLY_ORIGIN:
+            destination_response = self._destination_client.touch(
+                key=key, ttl=ttl, no_reply=no_reply
+            )
+        if migration_mode >= MigrationMode.USE_DESTINATION_UPDATE_ORIGIN:
+            assert destination_response is not None  # noqa: S101
+            return destination_response
+        else:
+            assert origin_response is not None  # noqa: S101
+            return origin_response
+
+    def get_counters(self) -> Dict[ServerAddress, PoolCounters]:
+        counters = self._origin_client.get_counters()
+        counters.update(self._destination_client.get_counters())
+        return counters

--- a/tests/migrating_cache_client_test.py
+++ b/tests/migrating_cache_client_test.py
@@ -1,0 +1,680 @@
+from unittest.mock import Mock
+
+import pytest
+from meta_memcache import CacheClient, IntFlag, Key, SetMode, Value, WriteFailureEvent
+from meta_memcache.extras.migrating_cache_client import (
+    MigratingCacheClient,
+    MigrationMode,
+)
+
+
+@pytest.fixture
+def origin_client() -> Mock:
+    return Mock(spec=CacheClient)
+
+
+@pytest.fixture
+def destination_client() -> Mock:
+    return Mock(spec=CacheClient)
+
+
+@pytest.fixture
+def time(monkeypatch) -> Mock:
+    time_mock = Mock()
+    monkeypatch.setattr("meta_memcache.extras.migrating_cache_client.time", time_mock)
+    return time_mock
+
+
+@pytest.fixture
+def random(monkeypatch) -> Mock:
+    random_mock = Mock()
+    monkeypatch.setattr(
+        "meta_memcache.extras.migrating_cache_client.random", random_mock
+    )
+    return random_mock
+
+
+@pytest.fixture
+def migration_client_origin_only(
+    origin_client: CacheClient, destination_client: CacheClient
+) -> MigratingCacheClient:
+    return MigratingCacheClient(
+        origin_client, destination_client, MigrationMode.ONLY_ORIGIN
+    )
+
+
+@pytest.fixture
+def migration_client_destination_only(
+    origin_client: CacheClient, destination_client: CacheClient
+) -> MigratingCacheClient:
+    return MigratingCacheClient(
+        origin_client, destination_client, MigrationMode.ONLY_DESTINATION
+    )
+
+
+@pytest.fixture
+def migration_client(
+    origin_client: CacheClient, destination_client: CacheClient
+) -> MigratingCacheClient:
+    return MigratingCacheClient(
+        origin_client,
+        destination_client,
+        migration_mode_config={
+            MigrationMode.ONLY_ORIGIN: 10,
+            MigrationMode.POPULATE_WRITES: 20,
+            MigrationMode.POPULATE_WRITES_AND_READS_1PCT: 30,
+            MigrationMode.POPULATE_WRITES_AND_READS_10PCT: 40,
+            MigrationMode.USE_DESTINATION_UPDATE_ORIGIN: 50,
+            MigrationMode.ONLY_DESTINATION: 60,
+        },
+    )
+
+
+def _set_cache_client_mock_get_return_values(client: Mock, ttl: int = 10) -> None:
+    client.meta_get.return_value = Value(
+        size=3,
+        value="bar",
+        flags=set(),
+        int_flags={IntFlag.TTL: ttl},
+        token_flags={},
+    )
+    client.meta_multiget.return_value = {
+        Key(key="foo", routing_key=None, is_unicode=False): Value(
+            size=3,
+            value="bar",
+            flags=set(),
+            int_flags={IntFlag.TTL: ttl},
+            token_flags={},
+        )
+    }
+
+
+def test_on_write_failure(
+    migration_client_origin_only: MigratingCacheClient,
+    origin_client: CacheClient,
+    destination_client: CacheClient,
+) -> None:
+    errors = []
+
+    def track_errors(key):
+        errors.append(key)
+
+    assert isinstance(migration_client_origin_only.on_write_failure, WriteFailureEvent)
+    migration_client_origin_only.on_write_failure += track_errors
+    origin_client.on_write_failure("key_on_origin")
+    destination_client.on_write_failure("key_on_destination")
+    assert errors == ["key_on_origin", "key_on_destination"]
+
+
+def test_migration_mode(time: Mock, migration_client: MigratingCacheClient) -> None:
+    time.time.return_value = 0
+    assert migration_client.get_migration_mode() == MigrationMode.ONLY_ORIGIN
+    time.time.return_value = 10
+    assert migration_client.get_migration_mode() == MigrationMode.ONLY_ORIGIN
+    time.time.return_value = 20
+    assert migration_client.get_migration_mode() == MigrationMode.POPULATE_WRITES
+    time.time.return_value = 30
+    assert (
+        migration_client.get_migration_mode()
+        == MigrationMode.POPULATE_WRITES_AND_READS_1PCT
+    )
+    time.time.return_value = 40
+    assert (
+        migration_client.get_migration_mode()
+        == MigrationMode.POPULATE_WRITES_AND_READS_10PCT
+    )
+    time.time.return_value = 50
+    assert (
+        migration_client.get_migration_mode()
+        == MigrationMode.USE_DESTINATION_UPDATE_ORIGIN
+    )
+    time.time.return_value = 60
+    assert migration_client.get_migration_mode() == MigrationMode.ONLY_DESTINATION
+
+
+def test_migration_mode_origin_only(
+    migration_client_origin_only: MigratingCacheClient,
+    origin_client: CacheClient,
+    destination_client: CacheClient,
+):
+    _set_cache_client_mock_get_return_values(origin_client)
+
+    # Gets
+    migration_client_origin_only.get(key="foo")
+    origin_client.meta_get.assert_called_once()
+    destination_client.meta_get.assert_not_called()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_not_called()
+
+    # Multi-gets
+    migration_client_origin_only.multi_get(keys=["foo"])
+    origin_client.meta_multiget.assert_called_once()
+    destination_client.meta_multiget.assert_not_called()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_not_called()
+
+    # Sets
+    migration_client_origin_only.set(key="foo", value="bar", ttl=10)
+    origin_client.meta_set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=10,
+        flags=set(),
+        int_flags={IntFlag.CACHE_TTL: 10},
+        token_flags=None,
+    )
+    destination_client.meta_set.assert_not_called()
+
+    # Deletes
+    migration_client_origin_only.delete(key="foo")
+    origin_client.meta_delete.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={},
+        token_flags=None,
+    )
+    destination_client.meta_delete.assert_not_called()
+
+    # Arithmetic
+    migration_client_origin_only.delta(key="foo", delta=1)
+    origin_client.meta_arithmetic.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={IntFlag.MA_DELTA_VALUE: 1},
+        token_flags={},
+    )
+    destination_client.meta_arithmetic.assert_not_called()
+
+    # Touch
+    migration_client_origin_only.touch(key="foo", ttl=10)
+    origin_client.touch.assert_called_once_with(key="foo", ttl=10, no_reply=False)
+    destination_client.touch.assert_not_called()
+
+
+def test_migration_mode_destination_only(
+    migration_client_destination_only: MigratingCacheClient,
+    origin_client: CacheClient,
+    destination_client: CacheClient,
+):
+    _set_cache_client_mock_get_return_values(destination_client)
+
+    # Gets
+    migration_client_destination_only.get(key="foo")
+    origin_client.meta_get.assert_not_called()
+    destination_client.meta_get.assert_called_once()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_not_called()
+
+    # Multi-get
+    migration_client_destination_only.multi_get(keys=["foo"])
+    origin_client.meta_multiget.assert_not_called()
+    destination_client.meta_multiget.assert_called_once()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_not_called()
+
+    # Sets
+    migration_client_destination_only.set(key="foo", value="bar", ttl=10)
+    origin_client.meta_set.assert_not_called()
+    destination_client.meta_set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=10,
+        flags=set(),
+        int_flags={IntFlag.CACHE_TTL: 10},
+        token_flags=None,
+    )
+
+    # Deletes
+    migration_client_destination_only.delete(key="foo")
+    origin_client.meta_delete.assert_not_called()
+    destination_client.meta_delete.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={},
+        token_flags=None,
+    )
+
+    # Arithmetic
+    migration_client_destination_only.delta(key="foo", delta=1)
+    origin_client.meta_arithmetic.assert_not_called()
+    destination_client.meta_arithmetic.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={IntFlag.MA_DELTA_VALUE: 1},
+        token_flags={},
+    )
+
+    # Touch
+    migration_client_destination_only.touch(key="foo", ttl=10)
+    origin_client.touch.assert_not_called()
+    destination_client.touch.assert_called_once_with(key="foo", ttl=10, no_reply=False)
+
+
+def test_migration_mode_populate_writes(
+    time: Mock,
+    migration_client: MigratingCacheClient,
+    origin_client: CacheClient,
+    destination_client: CacheClient,
+) -> None:
+    time.time.return_value = 20
+    assert migration_client.get_migration_mode() == MigrationMode.POPULATE_WRITES
+
+    _set_cache_client_mock_get_return_values(origin_client)
+
+    # Gets
+    migration_client.get(key="foo")
+    origin_client.meta_get.assert_called_once()
+    destination_client.meta_get.assert_not_called()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_not_called()
+
+    # Multi-get
+    migration_client.multi_get(keys=["foo"])
+    origin_client.meta_multiget.assert_called_once()
+    destination_client.meta_multiget.assert_not_called()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_not_called()
+
+    # Sets (both receive writes)
+    migration_client.set(key="foo", value="bar", ttl=10)
+    origin_client.meta_set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=10,
+        flags=set(),
+        int_flags={IntFlag.CACHE_TTL: 10},
+        token_flags=None,
+    )
+    destination_client.meta_set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=10,
+        flags=set(),
+        int_flags={IntFlag.CACHE_TTL: 10},
+        token_flags=None,
+    )
+
+    # Deletes (both receive writes)
+    migration_client.delete(key="foo")
+    origin_client.meta_delete.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={},
+        token_flags=None,
+    )
+    destination_client.meta_delete.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={},
+        token_flags=None,
+    )
+
+    # Arithmetic
+    migration_client.delta(key="foo", delta=1)
+    origin_client.meta_arithmetic.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={IntFlag.MA_DELTA_VALUE: 1},
+        token_flags={},
+    )
+    destination_client.meta_arithmetic.assert_not_called()
+
+    # Touch
+    migration_client.touch(key="foo", ttl=10)
+    origin_client.touch.assert_called_once_with(key="foo", ttl=10, no_reply=False)
+    destination_client.touch.assert_called_once_with(key="foo", ttl=10, no_reply=False)
+
+
+def test_migration_mode_populate_reads_handles_non_expiring_keys(
+    time: Mock,
+    random: Mock,
+    migration_client: MigratingCacheClient,
+    origin_client: CacheClient,
+    destination_client: CacheClient,
+) -> None:
+    time.time.return_value = 30
+    assert (
+        migration_client.get_migration_mode()
+        == MigrationMode.POPULATE_WRITES_AND_READS_1PCT
+    )
+
+    # Non expiring items in cache return ttl of -1, but
+    # we need to populate them as ttl=0
+    _set_cache_client_mock_get_return_values(origin_client, ttl=-1)
+    # Random says reads should be populated
+    random.getrandbits.return_value = 1000
+
+    # Gets
+    migration_client.get(key="foo")
+    origin_client.meta_get.assert_called_once()
+    destination_client.meta_get.assert_not_called()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=0,
+        no_reply=True,
+        set_mode=SetMode.ADD,
+    )
+    destination_client.set.reset_mock()
+
+    # Multi-get
+    migration_client.multi_get(keys=["foo"])
+    origin_client.meta_multiget.assert_called_once()
+    destination_client.meta_multiget.assert_not_called()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=0,
+        no_reply=True,
+        set_mode=SetMode.ADD,
+    )
+
+
+def test_migration_mode_populate_writes_and_reads_1pct(
+    time: Mock,
+    random: Mock,
+    migration_client: MigratingCacheClient,
+    origin_client: CacheClient,
+    destination_client: CacheClient,
+) -> None:
+    time.time.return_value = 30
+    assert (
+        migration_client.get_migration_mode()
+        == MigrationMode.POPULATE_WRITES_AND_READS_1PCT
+    )
+
+    _set_cache_client_mock_get_return_values(origin_client)
+
+    # Random says reads should NOT be populated
+    random.getrandbits.return_value = 1
+
+    # Gets (not populated)
+    migration_client.get(key="foo")
+    origin_client.meta_get.assert_called_once()
+    destination_client.meta_get.assert_not_called()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_not_called()
+
+    # Multi-get
+    migration_client.multi_get(keys=["foo"])
+    origin_client.meta_multiget.assert_called_once()
+    destination_client.meta_multiget.assert_not_called()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_not_called()
+
+    origin_client.meta_get.reset_mock()
+    origin_client.meta_multiget.reset_mock()
+
+    # Random says reads should be populated
+    random.getrandbits.return_value = 1000
+
+    # Gets
+    migration_client.get(key="foo")
+    origin_client.meta_get.assert_called_once()
+    destination_client.meta_get.assert_not_called()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=10,
+        no_reply=True,
+        set_mode=SetMode.ADD,
+    )
+    destination_client.set.reset_mock()
+
+    # Multi-get
+    migration_client.multi_get(keys=["foo"])
+    origin_client.meta_multiget.assert_called_once()
+    destination_client.meta_multiget.assert_not_called()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=10,
+        no_reply=True,
+        set_mode=SetMode.ADD,
+    )
+
+    # Sets (both receive writes)
+    migration_client.set(key="foo", value="bar", ttl=10)
+    origin_client.meta_set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=10,
+        flags=set(),
+        int_flags={IntFlag.CACHE_TTL: 10},
+        token_flags=None,
+    )
+    destination_client.meta_set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=10,
+        flags=set(),
+        int_flags={IntFlag.CACHE_TTL: 10},
+        token_flags=None,
+    )
+
+    # Deletes (both receive writes)
+    migration_client.delete(key="foo")
+    origin_client.meta_delete.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={},
+        token_flags=None,
+    )
+    destination_client.meta_delete.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={},
+        token_flags=None,
+    )
+
+    # Arithmetic
+    migration_client.delta(key="foo", delta=1)
+    origin_client.meta_arithmetic.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={IntFlag.MA_DELTA_VALUE: 1},
+        token_flags={},
+    )
+    destination_client.meta_arithmetic.assert_not_called()
+
+    # Touch
+    migration_client.touch(key="foo", ttl=10)
+    origin_client.touch.assert_called_once_with(key="foo", ttl=10, no_reply=False)
+    destination_client.touch.assert_called_once_with(key="foo", ttl=10, no_reply=False)
+
+
+def test_migration_mode_populate_writes_and_reads_10pct(
+    time: Mock,
+    random: Mock,
+    migration_client: MigratingCacheClient,
+    origin_client: CacheClient,
+    destination_client: CacheClient,
+) -> None:
+    time.time.return_value = 40
+    assert (
+        migration_client.get_migration_mode()
+        == MigrationMode.POPULATE_WRITES_AND_READS_10PCT
+    )
+
+    _set_cache_client_mock_get_return_values(origin_client)
+
+    # Random says reads should NOT be populated
+    random.getrandbits.return_value = 10
+
+    # Gets (not populated)
+    migration_client.get(key="foo")
+    origin_client.meta_get.assert_called_once()
+    destination_client.meta_get.assert_not_called()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_not_called()
+
+    # Multi-get
+    migration_client.multi_get(keys=["foo"])
+    origin_client.meta_multiget.assert_called_once()
+    destination_client.meta_multiget.assert_not_called()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_not_called()
+
+    origin_client.meta_get.reset_mock()
+    origin_client.meta_multiget.reset_mock()
+
+    # Random says reads should be populated
+    random.getrandbits.return_value = 1009
+
+    # Gets
+    migration_client.get(key="foo")
+    origin_client.meta_get.assert_called_once()
+    destination_client.meta_get.assert_not_called()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=10,
+        no_reply=True,
+        set_mode=SetMode.ADD,
+    )
+    destination_client.set.reset_mock()
+
+    # Multi-get
+    migration_client.multi_get(keys=["foo"])
+    origin_client.meta_multiget.assert_called_once()
+    destination_client.meta_multiget.assert_not_called()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=10,
+        no_reply=True,
+        set_mode=SetMode.ADD,
+    )
+
+    # Sets (both receive writes)
+    migration_client.set(key="foo", value="bar", ttl=10)
+    origin_client.meta_set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=10,
+        flags=set(),
+        int_flags={IntFlag.CACHE_TTL: 10},
+        token_flags=None,
+    )
+    destination_client.meta_set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=10,
+        flags=set(),
+        int_flags={IntFlag.CACHE_TTL: 10},
+        token_flags=None,
+    )
+
+    # Deletes (both receive writes)
+    migration_client.delete(key="foo")
+    origin_client.meta_delete.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={},
+        token_flags=None,
+    )
+    destination_client.meta_delete.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={},
+        token_flags=None,
+    )
+
+    # Arithmetic
+    migration_client.delta(key="foo", delta=1)
+    origin_client.meta_arithmetic.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={IntFlag.MA_DELTA_VALUE: 1},
+        token_flags={},
+    )
+    destination_client.meta_arithmetic.assert_not_called()
+
+    # Touch
+    migration_client.touch(key="foo", ttl=10)
+    origin_client.touch.assert_called_once_with(key="foo", ttl=10, no_reply=False)
+    destination_client.touch.assert_called_once_with(key="foo", ttl=10, no_reply=False)
+
+
+def test_migration_mode_use_destination_update_origin(
+    time: Mock,
+    migration_client: MigratingCacheClient,
+    origin_client: CacheClient,
+    destination_client: CacheClient,
+) -> None:
+    time.time.return_value = 50
+    assert (
+        migration_client.get_migration_mode()
+        == MigrationMode.USE_DESTINATION_UPDATE_ORIGIN
+    )
+
+    _set_cache_client_mock_get_return_values(destination_client)
+
+    # Gets
+    migration_client.get(key="foo")
+    origin_client.meta_get.assert_not_called()
+    destination_client.meta_get.assert_called_once()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_not_called()
+
+    # Multi-get
+    migration_client.multi_get(keys=["foo"])
+    origin_client.meta_multiget.assert_not_called()
+    destination_client.meta_multiget.assert_called_once()
+    origin_client.set.assert_not_called()
+    destination_client.set.assert_not_called()
+
+    # Sets (both receive writes)
+    migration_client.set(key="foo", value="bar", ttl=10)
+    origin_client.meta_set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=10,
+        flags=set(),
+        int_flags={IntFlag.CACHE_TTL: 10},
+        token_flags=None,
+    )
+    destination_client.meta_set.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        value="bar",
+        ttl=10,
+        flags=set(),
+        int_flags={IntFlag.CACHE_TTL: 10},
+        token_flags=None,
+    )
+
+    # Deletes (both receive writes)
+    migration_client.delete(key="foo")
+    origin_client.meta_delete.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={},
+        token_flags=None,
+    )
+    destination_client.meta_delete.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={},
+        token_flags=None,
+    )
+
+    # Arithmetic
+    migration_client.delta(key="foo", delta=1)
+    origin_client.meta_arithmetic.assert_not_called()
+    destination_client.meta_arithmetic.assert_called_once_with(
+        key=Key(key="foo", routing_key=None, is_unicode=False),
+        flags=set(),
+        int_flags={IntFlag.MA_DELTA_VALUE: 1},
+        token_flags={},
+    )
+
+    # Touch
+    migration_client.touch(key="foo", ttl=10)
+    origin_client.touch.assert_called_once_with(key="foo", ttl=10, no_reply=False)
+    destination_client.touch.assert_called_once_with(key="foo", ttl=10, no_reply=False)


### PR DESCRIPTION
## Motivation / Description
Implements a pool that can switch from one origin pool to a destination
pool smoothly, according to the given configuration.

It has several modes to smooth the transition, being able to warm up
the destination pool before switching reads to it.
