### PR TITLE
Add invalidate() high level method

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ Invalidation...
         stale_policy: Optional[StalePolicy] = None,
     ) -> bool:
 
+    def invalidate(
+        self,
+        key: Union[Key, str],
+        cas_token: Optional[int] = None,
+        no_reply: bool = False,
+        stale_policy: Optional[StalePolicy] = None,
+    ) -> bool:
+
     def touch(
         self,
         key: Union[Key, str],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meta-memcache"
-version = "1.0.1"
+version = "1.0.2"
 description = "Modern, pure python, memcache client with support for new meta commands."
 license = "MIT"
 readme = "README.md"

--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 from meta_memcache.cache_client import CacheClient
 from meta_memcache.configuration import (

--- a/src/meta_memcache/interfaces/high_level_commands.py
+++ b/src/meta_memcache/interfaces/high_level_commands.py
@@ -26,6 +26,24 @@ class HighLevelCommandsProtocol(Protocol):
         no_reply: bool = False,
         stale_policy: Optional[StalePolicy] = None,
     ) -> bool:
+        """
+        Returns True if the key existed and it was deleted.
+        If the key is not found in the cache it will return False. If
+        you just want to the key to be deleted not caring of whether
+        it exists or not, use invalidate() instead.
+        """
+        ...  # pragma: no cover
+
+    def invalidate(
+        self,
+        key: Union[Key, str],
+        cas_token: Optional[int] = None,
+        no_reply: bool = False,
+        stale_policy: Optional[StalePolicy] = None,
+    ) -> bool:
+        """
+        Returns true of the key deleted or it didn't exist anyway
+        """
         ...  # pragma: no cover
 
     def touch(

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -338,8 +338,77 @@ def test_delete_success_fail(
     result = cache_client.delete(key=Key("foo"))
     assert result is True
 
+    memcache_socket.get_response.return_value = Miss()
+    result = cache_client.delete(key=Key("foo"))
+    assert result is False
+
     memcache_socket.get_response.return_value = NotStored()
     result = cache_client.delete(key=Key("foo"))
+    assert result is False
+
+
+def test_invalidate_cmd(
+    memcache_socket: MemcacheSocket,
+    cache_client: CacheClient,
+) -> None:
+    memcache_socket.get_response.return_value = Success()
+
+    cache_client.invalidate(key="foo")
+    memcache_socket.sendall.assert_called_once_with(b"md foo\r\n", with_noop=False)
+    memcache_socket.get_response.assert_called_once_with()
+    memcache_socket.sendall.reset_mock()
+    memcache_socket.get_response.reset_mock()
+
+    cache_client.invalidate(key=Key("foo"))
+    memcache_socket.sendall.assert_called_once_with(b"md foo\r\n", with_noop=False)
+    memcache_socket.get_response.assert_called_once_with()
+    memcache_socket.sendall.reset_mock()
+    memcache_socket.get_response.reset_mock()
+
+    cache_client.invalidate(key=Key("foo"), cas_token=666)
+    memcache_socket.sendall.assert_called_once_with(b"md foo C666\r\n", with_noop=False)
+    memcache_socket.get_response.assert_called_once_with()
+    memcache_socket.sendall.reset_mock()
+    memcache_socket.get_response.reset_mock()
+
+    cache_client.invalidate(key=Key("foo"), no_reply=True)
+    memcache_socket.sendall.assert_called_once_with(b"md foo q\r\n", with_noop=True)
+    memcache_socket.get_response.assert_not_called()
+    memcache_socket.sendall.reset_mock()
+    memcache_socket.get_response.reset_mock()
+
+    cache_client.invalidate(key=Key("foo"), stale_policy=StalePolicy())
+    memcache_socket.sendall.assert_called_once_with(b"md foo\r\n", with_noop=False)
+    memcache_socket.get_response.assert_called_once_with()
+    memcache_socket.sendall.reset_mock()
+    memcache_socket.get_response.reset_mock()
+
+    cache_client.invalidate(
+        key=Key("foo"),
+        stale_policy=StalePolicy(mark_stale_on_deletion_ttl=30),
+    )
+    memcache_socket.sendall.assert_called_once_with(
+        b"md foo I T30\r\n", with_noop=False
+    )
+    memcache_socket.get_response.assert_called_once_with()
+    memcache_socket.sendall.reset_mock()
+    memcache_socket.get_response.reset_mock()
+
+
+def test_invalidate_success_fail(
+    memcache_socket: MemcacheSocket,
+    cache_client: CacheClient,
+) -> None:
+    memcache_socket.get_response.return_value = Success()
+    result = cache_client.invalidate(key=Key("foo"))
+    assert result is True
+
+    memcache_socket.get_response.return_value = Miss()
+    result = cache_client.invalidate(key=Key("foo"))
+    assert result is True
+
+    memcache_socket.get_response.return_value = NotStored()
+    result = cache_client.invalidate(key=Key("foo"))
     assert result is False
 
 


### PR DESCRIPTION
## Motivation / Description
Invalidate is an useful high-level method that will return true
if a key is correctly deleted or didn't exist it cache.

## Changes introduced
- Add invalidate()
