### PR TITLE
Fix closed socket detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meta-memcache"
-version = "1.0.2"
+version = "1.0.3"
 description = "Modern, pure python, memcache client with support for new meta commands."
 license = "MIT"
 readme = "README.md"

--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 from meta_memcache.cache_client import CacheClient
 from meta_memcache.configuration import (

--- a/src/meta_memcache/connection/memcache_socket.py
+++ b/src/meta_memcache/connection/memcache_socket.py
@@ -132,7 +132,7 @@ class MemcacheSocket:
         endl_pos = self._buf.find(ENDL, self._pos, self._read)
         while endl_pos < 0 and self._read < self._buffer_size:
             # Missing data, but still space in buffer, so read more
-            if self._recv_info_buffer() < 0:
+            if self._recv_info_buffer() <= 0:
                 break
             endl_pos = self._buf.find(ENDL, self._pos, self._read)
 

--- a/tests/memcache_socket_test.py
+++ b/tests/memcache_socket_test.py
@@ -108,6 +108,15 @@ def test_noreply(
     assert isinstance(ms.get_response(), Success)
 
 
+def test_socket_closed(
+    fake_socket: socket.socket,
+) -> None:
+    fake_socket.recv_into.side_effect = recv_into_mock([b""])
+    ms = MemcacheSocket(fake_socket)
+    with pytest.raises(MemcacheError):
+        ms.get_response()
+
+
 def test_get_value(
     fake_socket: socket.socket,
 ) -> None:


### PR DESCRIPTION
## Motivation / Description
If the socket is closed unexpectedly we keep trying to read
from socket and keep getting 0 bytes.

## Changes introduced
- break if we read 0 bytes from socket
