### PR TITLE
Clear hot cache on origin miss

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meta-memcache"
-version = "1.0.3"
+version = "1.0.4"
 description = "Modern, pure python, memcache client with support for new meta commands."
 license = "MIT"
 readme = "README.md"

--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 from meta_memcache.cache_client import CacheClient
 from meta_memcache.configuration import (


### PR DESCRIPTION
## Motivation / Description
While rare, a hot entry can get deleted and we need
to clear the hot cache when the origin returns miss
and the revalidation time has elapsed.
