### PR TITLE
Fix cache clear on multi_get misses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meta-memcache"
-version = "1.0.4"
+version = "1.0.5"
 description = "Modern, pure python, memcache client with support for new meta commands."
 license = "MIT"
 readme = "README.md"

--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.4"
+__version__ = "1.0.5"
 
 from meta_memcache.cache_client import CacheClient
 from meta_memcache.configuration import (

--- a/src/meta_memcache/extras/probabilistic_hot_cache.py
+++ b/src/meta_memcache/extras/probabilistic_hot_cache.py
@@ -217,6 +217,7 @@ class ProbabilisticHotCache(ClientWrapper):
             )
             for key, result in results.items():
                 allowed = key not in ineligible_keys
+                is_hot = key in values if allowed else False
                 if result is None:
                     allowed and self._metrics and self._metrics.metric_inc(
                         "candidate_misses"
@@ -224,10 +225,6 @@ class ProbabilisticHotCache(ClientWrapper):
                     is_hot and self._clear_hot_cache_if_necessary(key)
                     values[key] = None
                 else:
-                    if allowed:
-                        is_hot = key in values
-                    else:
-                        is_hot = False
                     self._store_in_hot_cache_if_necessary(key, result, is_hot, allowed)
                     values[key] = result.value
         return values


### PR DESCRIPTION
## Motivation / Description
There was a bug, is_hot was not always properly set for the miss on
multiget
