### PR TITLE
Expose track write failures flag in meta-commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meta-memcache"
-version = "1.0.5"
+version = "1.1.0"
 description = "Modern, pure python, memcache client with support for new meta commands."
 license = "MIT"
 readme = "README.md"

--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.5"
+__version__ = "1.1.0"
 
 from meta_memcache.cache_client import CacheClient
 from meta_memcache.configuration import (
@@ -25,7 +25,12 @@ from meta_memcache.interfaces.commands import CommandsProtocol
 from meta_memcache.interfaces.executor import Executor
 from meta_memcache.interfaces.high_level_commands import HighLevelCommandsProtocol
 from meta_memcache.interfaces.meta_commands import MetaCommandsProtocol
-from meta_memcache.interfaces.router import HasRouter, Router
+from meta_memcache.interfaces.router import (
+    DEFAULT_FAILURE_HANDLING,
+    FailureHandling,
+    HasRouter,
+    Router,
+)
 from meta_memcache.protocol import (
     Conflict,
     Flag,

--- a/src/meta_memcache/commands/meta_commands.py
+++ b/src/meta_memcache/commands/meta_commands.py
@@ -1,7 +1,11 @@
 from typing import Any, Dict, List, Optional, Set
 
 from meta_memcache.errors import MemcacheError
-from meta_memcache.interfaces.router import HasRouter
+from meta_memcache.interfaces.router import (
+    DEFAULT_FAILURE_HANDLING,
+    FailureHandling,
+    HasRouter,
+)
 from meta_memcache.protocol import (
     Conflict,
     Flag,
@@ -26,6 +30,7 @@ class MetaCommandsMixin:
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> Dict[Key, ReadResponse]:
         results: Dict[Key, ReadResponse] = {}
         for key, result in self.router.exec_multi(
@@ -34,6 +39,7 @@ class MetaCommandsMixin:
             flags=flags,
             int_flags=int_flags,
             token_flags=token_flags,
+            failure_handling=failure_handling,
         ).items():
             if not isinstance(result, (Miss, Value, Success)):
                 raise MemcacheError(
@@ -48,6 +54,7 @@ class MetaCommandsMixin:
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> ReadResponse:
         result = self.router.exec(
             command=MetaCommand.META_GET,
@@ -55,6 +62,7 @@ class MetaCommandsMixin:
             flags=flags,
             int_flags=int_flags,
             token_flags=token_flags,
+            failure_handling=failure_handling,
         )
         if not isinstance(result, (Miss, Value, Success)):
             raise MemcacheError(f"Unexpected response for Meta Get command: {result}")
@@ -68,6 +76,7 @@ class MetaCommandsMixin:
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         result = self.router.exec(
             command=MetaCommand.META_SET,
@@ -76,6 +85,7 @@ class MetaCommandsMixin:
             flags=flags,
             int_flags=int_flags,
             token_flags=token_flags,
+            failure_handling=failure_handling,
         )
         if not isinstance(result, (Success, NotStored, Conflict, Miss)):
             raise MemcacheError(f"Unexpected response for Meta Set command: {result}")
@@ -87,6 +97,7 @@ class MetaCommandsMixin:
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         result = self.router.exec(
             command=MetaCommand.META_DELETE,
@@ -94,6 +105,7 @@ class MetaCommandsMixin:
             flags=flags,
             int_flags=int_flags,
             token_flags=token_flags,
+            failure_handling=failure_handling,
         )
         if not isinstance(result, (Success, NotStored, Conflict, Miss)):
             raise MemcacheError(
@@ -107,6 +119,7 @@ class MetaCommandsMixin:
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         result = self.router.exec(
             command=MetaCommand.META_ARITHMETIC,
@@ -114,6 +127,7 @@ class MetaCommandsMixin:
             flags=flags,
             int_flags=int_flags,
             token_flags=token_flags,
+            failure_handling=failure_handling,
         )
         if not isinstance(result, (Success, NotStored, Conflict, Miss, Value)):
             raise MemcacheError(

--- a/src/meta_memcache/executors/default.py
+++ b/src/meta_memcache/executors/default.py
@@ -109,11 +109,6 @@ class DefaultExecutor:
         track_write_failures: bool,
         raise_on_server_error: Optional[bool] = None,
     ) -> MemcacheResponse:
-        raise_on_server_error = (
-            raise_on_server_error
-            if raise_on_server_error is not None
-            else self._raise_on_server_error
-        )
         cmd_value, int_flags = (
             (None, int_flags)
             if value is None
@@ -134,6 +129,11 @@ class DefaultExecutor:
         except MemcacheServerError:
             if track_write_failures and self._is_a_write_failure(command, int_flags):
                 self.on_write_failure(key)
+            raise_on_server_error = (
+                raise_on_server_error
+                if raise_on_server_error is not None
+                else self._raise_on_server_error
+            )
             if raise_on_server_error:
                 raise
             if command == MetaCommand.META_GET:
@@ -152,11 +152,6 @@ class DefaultExecutor:
         track_write_failures: bool,
         raise_on_server_error: Optional[bool] = None,
     ) -> Dict[Key, MemcacheResponse]:
-        raise_on_server_error = (
-            raise_on_server_error
-            if raise_on_server_error is not None
-            else self._raise_on_server_error
-        )
         results: Dict[Key, MemcacheResponse] = {}
         try:
             with pool.get_connection() as conn:
@@ -184,6 +179,11 @@ class DefaultExecutor:
             if track_write_failures and self._is_a_write_failure(command, int_flags):
                 for key, _ in key_values:
                     self.on_write_failure(key)
+            raise_on_server_error = (
+                raise_on_server_error
+                if raise_on_server_error is not None
+                else self._raise_on_server_error
+            )
             if raise_on_server_error:
                 raise
             failure_result = Miss() if command == MetaCommand.META_GET else NotStored()

--- a/src/meta_memcache/extras/client_wrapper.py
+++ b/src/meta_memcache/extras/client_wrapper.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional, Set
 from meta_memcache.commands.high_level_commands import HighLevelCommandsMixin
 from meta_memcache.configuration import ServerAddress
 from meta_memcache.connection.pool import PoolCounters
+from meta_memcache.interfaces.router import FailureHandling, DEFAULT_FAILURE_HANDLING
 from meta_memcache.interfaces.cache_api import CacheApi
 from meta_memcache.protocol import (
     Flag,
@@ -35,12 +36,14 @@ class ClientWrapper(HighLevelCommandsMixin):
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> Dict[Key, ReadResponse]:
         return self.client.meta_multiget(
             keys=keys,
             flags=flags,
             int_flags=int_flags,
             token_flags=token_flags,
+            failure_handling=failure_handling,
         )
 
     def meta_get(
@@ -49,12 +52,14 @@ class ClientWrapper(HighLevelCommandsMixin):
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> ReadResponse:
         return self.client.meta_get(
             key=key,
             flags=flags,
             int_flags=int_flags,
             token_flags=token_flags,
+            failure_handling=failure_handling,
         )
 
     def meta_set(
@@ -65,6 +70,7 @@ class ClientWrapper(HighLevelCommandsMixin):
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         return self.client.meta_set(
             key=key,
@@ -73,6 +79,7 @@ class ClientWrapper(HighLevelCommandsMixin):
             flags=flags,
             int_flags=int_flags,
             token_flags=token_flags,
+            failure_handling=failure_handling,
         )
 
     def meta_delete(
@@ -81,12 +88,14 @@ class ClientWrapper(HighLevelCommandsMixin):
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         return self.client.meta_delete(
             key=key,
             flags=flags,
             int_flags=int_flags,
             token_flags=token_flags,
+            failure_handling=failure_handling,
         )
 
     def meta_arithmetic(
@@ -95,12 +104,14 @@ class ClientWrapper(HighLevelCommandsMixin):
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         return self.client.meta_arithmetic(
             key=key,
             flags=flags,
             int_flags=int_flags,
             token_flags=token_flags,
+            failure_handling=failure_handling,
         )
 
     def get_counters(self) -> Dict[ServerAddress, PoolCounters]:

--- a/src/meta_memcache/interfaces/high_level_commands.py
+++ b/src/meta_memcache/interfaces/high_level_commands.py
@@ -19,6 +19,31 @@ class HighLevelCommandsProtocol(Protocol):
     ) -> bool:
         ...  # pragma: no cover
 
+    def refill(
+        self,
+        key: Union[Key, str],
+        value: Any,
+        ttl: int,
+        no_reply: bool = False,
+    ) -> bool:
+        """
+        Try to refill a value.
+
+        Use this method when you got a cache miss, read from DB and
+        are trying to refill the value.
+
+        DO NOT USE to write new state.
+
+        It will:
+         * use "ADD" mode, so it will fail if the value is already
+           present in cache.
+         * It will also disable write failure tracking. The write
+           failure tracking is often used to invalidate keys that
+           fail to be written. Since this is not writting new state,
+           there is no need to track failures.
+        """
+        ...  # pragma: no cover
+
     def delete(
         self,
         key: Union[Key, str],

--- a/src/meta_memcache/interfaces/meta_commands.py
+++ b/src/meta_memcache/interfaces/meta_commands.py
@@ -1,6 +1,6 @@
-from typing import Protocol
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Protocol, Set
 
+from meta_memcache.interfaces.router import FailureHandling, DEFAULT_FAILURE_HANDLING
 from meta_memcache.protocol import (
     Flag,
     IntFlag,
@@ -18,6 +18,7 @@ class MetaCommandsProtocol(Protocol):
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> Dict[Key, ReadResponse]:
         ...  # pragma: no cover
 
@@ -27,6 +28,7 @@ class MetaCommandsProtocol(Protocol):
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> ReadResponse:
         ...  # pragma: no cover
 
@@ -38,6 +40,7 @@ class MetaCommandsProtocol(Protocol):
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         ...  # pragma: no cover
 
@@ -47,6 +50,7 @@ class MetaCommandsProtocol(Protocol):
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         ...  # pragma: no cover
 
@@ -56,5 +60,6 @@ class MetaCommandsProtocol(Protocol):
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         ...  # pragma: no cover

--- a/src/meta_memcache/interfaces/router.py
+++ b/src/meta_memcache/interfaces/router.py
@@ -1,8 +1,8 @@
-from typing import Dict, List, Optional, Protocol, Set
+from typing import Dict, List, NamedTuple, Optional, Protocol, Set
+
 from meta_memcache.configuration import ServerAddress
 from meta_memcache.connection.pool import PoolCounters
 from meta_memcache.interfaces.executor import Executor
-
 from meta_memcache.protocol import (
     Flag,
     IntFlag,
@@ -15,6 +15,19 @@ from meta_memcache.protocol import (
 )
 
 
+class FailureHandling(NamedTuple):
+    """
+    Override the default failure handling for a execution
+    """
+
+    # None means use the default for the pool
+    raise_on_server_error: Optional[bool] = None
+    track_write_failures: bool = True
+
+
+DEFAULT_FAILURE_HANDLING = FailureHandling()
+
+
 class Router(Protocol):
     def exec(
         self,
@@ -24,6 +37,7 @@ class Router(Protocol):
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> MemcacheResponse:
         """
         Gets a connection for the key and executes the command
@@ -41,6 +55,7 @@ class Router(Protocol):
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> Dict[Key, MemcacheResponse]:
         """
         Groups keys by destination, gets a connection and executes the commands

--- a/src/meta_memcache/routers/default.py
+++ b/src/meta_memcache/routers/default.py
@@ -1,10 +1,11 @@
 from collections import defaultdict
 from typing import Callable, DefaultDict, Dict, List, Optional, Set, Tuple
-from meta_memcache.configuration import ServerAddress
 
+from meta_memcache.configuration import ServerAddress
 from meta_memcache.connection.pool import ConnectionPool, PoolCounters
 from meta_memcache.connection.providers import ConnectionPoolProvider
 from meta_memcache.interfaces.executor import Executor
+from meta_memcache.interfaces.router import DEFAULT_FAILURE_HANDLING, FailureHandling
 from meta_memcache.protocol import (
     Flag,
     IntFlag,
@@ -34,6 +35,7 @@ class DefaultRouter:
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> MemcacheResponse:
         """
         Gets a connection for the key and executes the command
@@ -49,7 +51,8 @@ class DefaultRouter:
             flags=flags,
             int_flags=int_flags,
             token_flags=token_flags,
-            track_write_failures=True,
+            track_write_failures=failure_handling.track_write_failures,
+            raise_on_server_error=failure_handling.raise_on_server_error,
         )
 
     def exec_multi(
@@ -60,6 +63,7 @@ class DefaultRouter:
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> Dict[Key, MemcacheResponse]:
         """
         Groups keys by destination, gets a connection and executes the commands
@@ -76,7 +80,8 @@ class DefaultRouter:
                     flags=flags,
                     int_flags=int_flags,
                     token_flags=token_flags,
-                    track_write_failures=True,
+                    track_write_failures=failure_handling.track_write_failures,
+                    raise_on_server_error=failure_handling.raise_on_server_error,
                 )
             )
         return results

--- a/src/meta_memcache/routers/ephemeral.py
+++ b/src/meta_memcache/routers/ephemeral.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional, Set
 
 from meta_memcache.connection.providers import ConnectionPoolProvider
 from meta_memcache.interfaces.executor import Executor
+from meta_memcache.interfaces.router import DEFAULT_FAILURE_HANDLING, FailureHandling
 from meta_memcache.protocol import (
     Flag,
     IntFlag,
@@ -54,6 +55,7 @@ class EphemeralRouter(DefaultRouter):
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> MemcacheResponse:
         return super().exec(
             command=command,
@@ -62,6 +64,7 @@ class EphemeralRouter(DefaultRouter):
             flags=flags,
             int_flags=adjust_int_flags_for_max_ttl(int_flags, self._max_ttl),
             token_flags=token_flags,
+            failure_handling=failure_handling,
         )
 
     def exec_multi(
@@ -72,6 +75,7 @@ class EphemeralRouter(DefaultRouter):
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> Dict[Key, MemcacheResponse]:
         return super().exec_multi(
             command=command,
@@ -80,4 +84,5 @@ class EphemeralRouter(DefaultRouter):
             flags=flags,
             int_flags=adjust_int_flags_for_max_ttl(int_flags, self._max_ttl),
             token_flags=token_flags,
+            failure_handling=failure_handling,
         )

--- a/tests/probabilistic_hot_cache_test.py
+++ b/tests/probabilistic_hot_cache_test.py
@@ -2,6 +2,7 @@ from typing import Dict, List, Optional, Set
 from unittest.mock import Mock
 
 from prometheus_client import CollectorRegistry
+from meta_memcache.interfaces.router import DEFAULT_FAILURE_HANDLING, FailureHandling
 
 import pytest
 
@@ -22,6 +23,7 @@ def client() -> Mock:
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> ReadResponse:
         if key.key.endswith("hot"):
             return Value(
@@ -49,6 +51,7 @@ def client() -> Mock:
         flags: Optional[Set[Flag]] = None,
         int_flags: Optional[Dict[IntFlag, int]] = None,
         token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> Dict[Key, ReadResponse]:
         return {key: meta_get(key=key) for key in keys}
 
@@ -84,6 +87,7 @@ DEFAULT_FLAGS = {
     },
     "int_flags": {},
     "token_flags": None,
+    "failure_handling": DEFAULT_FAILURE_HANDLING,
 }
 
 


### PR DESCRIPTION
## Motivation / Description
We want to make possible to disable the write failure tracker
for certain commands, so we are exposing the track_write_failures
as a flag in all meta commands.

The rationale for this is that we want the refill write errors
to not cause a write failure and subsequent invalidation.

If a cache is down, reads will cause a miss. This will make
the client read from the backend and attempt to repopulate the
cache. If that write fails, it is fine to ignore it. Recording
it for invalidation might lead to invalidation storms and performance
degradation. Only writes during create, update and delete operations,
when the DB is actually being changed should be tracked as failures.

## Changes introduced
- Make routers pass the track_write_failure flag to executors
- Make mete commands expose track_write_failure flag
- Make a high-level refill command that will issue an set with mode ADD
  and disable write failure tracking.
