### PR TITLE
Do not use context manager for connection pool borrowing

### DIFF
--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -68,7 +68,7 @@ def connection_pool(
     mocker: MockerFixture, memcache_socket: MemcacheSocket
 ) -> ConnectionPool:
     connection_pool = mocker.MagicMock(spec=ConnectionPool)
-    connection_pool.get_connection().__enter__.return_value = memcache_socket
+    connection_pool.pop_connection.return_value = memcache_socket
     return connection_pool
 
 
@@ -77,7 +77,7 @@ def connection_pool_1_6_6(
     mocker: MockerFixture, memcache_socket_1_6_6: MemcacheSocket
 ) -> ConnectionPool:
     connection_pool = mocker.MagicMock(spec=ConnectionPool)
-    connection_pool.get_connection().__enter__.return_value = memcache_socket_1_6_6
+    connection_pool.pop_connection.return_value = memcache_socket_1_6_6
     return connection_pool
 
 
@@ -999,7 +999,7 @@ def test_on_write_failure(
     on_failure: Callable[[Key], None] = lambda key: failures_tracked.append(key)
     cache_client.on_write_failure += on_failure
 
-    connection_pool.get_connection.side_effect = MemcacheServerError(
+    connection_pool.pop_connection.side_effect = MemcacheServerError(
         server="broken:11211", message="uh-oh"
     )
     try:
@@ -1029,7 +1029,7 @@ def test_on_write_failure_for_reads(
     on_failure: Callable[[Key], None] = lambda key: failures_tracked.append(key)
     cache_client.on_write_failure += on_failure
 
-    connection_pool.get_connection.side_effect = MemcacheServerError(
+    connection_pool.pop_connection.side_effect = MemcacheServerError(
         server="broken:11211", message="uh-oh"
     )
     try:
@@ -1065,7 +1065,7 @@ def test_on_write_failure_for_multi_ops(
     on_failure: Callable[[Key], None] = lambda key: failures_tracked.append(key)
     cache_client.on_write_failure += on_failure
 
-    connection_pool.get_connection.side_effect = MemcacheServerError(
+    connection_pool.pop_connection.side_effect = MemcacheServerError(
         server="broken:11211", message="uh-oh"
     )
 
@@ -1094,7 +1094,7 @@ def test_on_write_failure_disabled(
     on_failure: Callable[[Key], None] = lambda key: failures_tracked.append(key)
     cache_client.on_write_failure += on_failure
 
-    connection_pool.get_connection.side_effect = MemcacheServerError(
+    connection_pool.pop_connection.side_effect = MemcacheServerError(
         server="broken:11211", message="uh-oh"
     )
     try:
@@ -1129,7 +1129,7 @@ def test_write_failure_not_raise_on_server_error(
     on_failure: Callable[[Key], None] = lambda key: failures_tracked.append(key)
     cache_client.on_write_failure += on_failure
 
-    connection_pool.get_connection.side_effect = MemcacheServerError(
+    connection_pool.pop_connection.side_effect = MemcacheServerError(
         server="broken:11211", message="uh-oh"
     )
     result = cache_client.get(key=Key("foo"))
@@ -1214,8 +1214,6 @@ def test_delta_cmd(memcache_socket: MemcacheSocket, cache_client: CacheClient) -
     )
     memcache_socket.sendall.reset_mock()
     memcache_socket.get_response.reset_mock()
-
-    # memcache_socket.get_response.return_value = Value(size=2, b"10")
 
     memcache_socket.get_response.return_value = Success()
 


### PR DESCRIPTION
Turns out at this micro-optimization level a context manager is quite expensive. It builds an object to encapsulate the context and that adds gc pressure on top of overall slowness. Removing this provides 0.6-0.8us ~10% improvement and softens gc latency spikes in production.

Before:
multithreaded: Overall: 135509.96 RPS / 7.38 us/req
singlethreaded: Overall: 137630.69 RPS / 7.27 us/req
After:
multithreaded: Overall: 151058.43 RPS / 6.62 us/req
singlethreaded: Overall: 151288.67 RPS / 6.61 us/req


Before:
![Screenshot 2023-11-06 at 12 27 19](https://github.com/RevenueCat/meta-memcache-py/assets/1917/fe390bb2-70b2-465a-af5a-fe64872dc1b3)
After:
![Screenshot 2023-11-06 at 12 27 34](https://github.com/RevenueCat/meta-memcache-py/assets/1917/6f4d03fb-63a1-4ca2-a825-a32e6cd7257b)
