### PR TITLE
Refactor response flag parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "meta-memcache"
-version = "1.1.2"
+version = "2.0.0a1"
 description = "Modern, pure python, memcache client with support for new meta commands."
 license = "MIT"
 readme = "README.md"

--- a/src/meta_memcache/executors/default.py
+++ b/src/meta_memcache/executors/default.py
@@ -252,12 +252,12 @@ class DefaultExecutor:
         Read response on a connection
         """
         if flags and Flag.NOREPLY in flags:
-            return Success(flags=set([Flag.NOREPLY]))
+            return Success()
         result = conn.get_response()
         if isinstance(result, Value):
             data = conn.get_value(result.size)
             if result.size > 0:
-                encoding_id = result.int_flags.get(IntFlag.CLIENT_FLAG, 0)
+                encoding_id = result.client_flag or 0
                 try:
                     result.value = self._serializer.unserialize(data, encoding_id)
                 except Exception:

--- a/src/meta_memcache/extras/migrating_cache_client.py
+++ b/src/meta_memcache/extras/migrating_cache_client.py
@@ -78,7 +78,7 @@ class MigratingCacheClient(HighLevelCommandsMixin):
             return current_mode
 
     def _get_value_ttl(self, value: Value) -> int:
-        ttl = value.int_flags.get(IntFlag.TTL, self._default_read_backfill_ttl)
+        ttl = value.ttl if value.ttl is not None else self._default_read_backfill_ttl
         if ttl < 0:
             # TTL for items marked to store forvered is returned as -1
             ttl = 0

--- a/src/meta_memcache/extras/probabilistic_hot_cache.py
+++ b/src/meta_memcache/extras/probabilistic_hot_cache.py
@@ -10,7 +10,7 @@ from meta_memcache.configuration import RecachePolicy
 from meta_memcache.extras.client_wrapper import ClientWrapper
 from meta_memcache.interfaces.cache_api import CacheApi
 from meta_memcache.metrics.base import BaseMetricsCollector, MetricDefinition
-from meta_memcache.protocol import IntFlag, Key, Value
+from meta_memcache.protocol import Key, Value
 
 
 @dataclass
@@ -124,8 +124,8 @@ class ProbabilisticHotCache(ClientWrapper):
         allowed: bool,
     ) -> None:
         if not is_hot:
-            hit_after_write = value.int_flags.get(IntFlag.HIT_AFTER_WRITE, 0)
-            last_read_age = value.int_flags.get(IntFlag.LAST_READ_AGE, 9999)
+            hit_after_write = value.fetched or 0
+            last_read_age = value.last_access if value.last_access is not None else 9999
             if (
                 hit_after_write > 0
                 and last_read_age <= self._max_last_access_age_seconds

--- a/src/meta_memcache/protocol.py
+++ b/src/meta_memcache/protocol.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum, IntEnum
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Union
 
 ENDL = b"\r\n"
 NOOP: bytes = b"mn" + ENDL
@@ -56,30 +56,21 @@ class Flag(Enum):
     RETURN_FETCHED = b"h"
     RETURN_KEY = b"k"
     NO_UPDATE_LRU = b"u"
-    WIN = b"W"
-    LOST = b"Z"
-    STALE = b"X"
     MARK_STALE = b"I"
 
 
 class IntFlag(Enum):
-    TTL = b"t"
     CACHE_TTL = b"T"
     RECACHE_TTL = b"R"
     MISS_LEASE_TTL = b"N"
-    CLIENT_FLAG = b"f"
     SET_CLIENT_FLAG = b"F"
-    LAST_READ_AGE = b"l"
-    HIT_AFTER_WRITE = b"h"
     MA_INITIAL_VALUE = b"J"
     MA_DELTA_VALUE = b"D"
-    RETURNED_CAS_TOKEN = b"c"
     CAS_TOKEN = b"C"
 
 
 class TokenFlag(Enum):
     OPAQUE = b"O"
-    KEY = b"k"
     # 'M' (mode switch):
     # * Meta Arithmetic:
     #  - I or +: increment
@@ -108,42 +99,171 @@ class MemcacheResponse:
 class Miss(MemcacheResponse):
     __slots__ = ()
 
+    pass
 
+
+# Response flags
+TOKEN_FLAG_OPAQUE = ord("O")
+INT_FLAG_CAS_TOKEN = ord("c")
+INT_FLAG_FETCHED = ord("h")
+INT_FLAG_LAST_ACCESS = ord("l")
+INT_FLAG_TTL = ord("t")
+INT_FLAG_CLIENT_FLAG = ord("f")
+INT_FLAG_SIZE = ord("s")
+FLAG_WIN = ord("W")
+FLAG_LOST = ord("Z")
+FLAG_STALE = ord("X")
+
+
+# @dataclass(slots=True, init=False)
 @dataclass
 class Success(MemcacheResponse):
-    __slots__ = ("flags", "int_flags", "token_flags")
-    flags: Set[Flag]
-    int_flags: Dict[IntFlag, int]
-    token_flags: Dict[TokenFlag, bytes]
+    __slots__ = (
+        "cas_token",
+        "fetched",
+        "last_access",
+        "ttl",
+        "client_flag",
+        "win",
+        "stale",
+        "real_size",
+        "opaque",
+    )
+    cas_token: Optional[int]
+    fetched: Optional[int]
+    last_access: Optional[int]
+    ttl: Optional[int]
+    client_flag: Optional[int]
+    win: Optional[bool]
+    stale: bool
+    real_size: Optional[int]
+    opaque: Optional[bytes]
 
     def __init__(
         self,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        *,
+        cas_token: Optional[int] = None,
+        fetched: Optional[int] = None,
+        last_access: Optional[int] = None,
+        ttl: Optional[int] = None,
+        client_flag: Optional[int] = None,
+        win: Optional[bool] = None,
+        stale: bool = False,
+        real_size: Optional[int] = None,
+        opaque: Optional[bytes] = None,
     ) -> None:
-        self.flags = flags or set()
-        self.int_flags = int_flags or {}
-        self.token_flags = token_flags or {}
+        self.cas_token = cas_token
+        self.fetched = fetched
+        self.last_access = last_access
+        self.ttl = ttl
+        self.client_flag = client_flag
+        self.win = win
+        self.stale = stale
+        self.real_size = real_size
+        self.opaque = opaque
+
+    @classmethod
+    def from_header(cls, header: "Blob") -> "Success":
+        result = cls()
+        result._set_flags(header)
+        return result
+
+    def _set_flags(self, header: bytes, pos: int = 3) -> None:  # noqa: C901
+        header_size = len(header)
+        while pos < header_size:
+            flag = header[pos]
+            pos += 1
+            if flag == SPACE:
+                continue
+            end = pos
+            while end < header_size:
+                if header[end] == SPACE:
+                    break
+                end += 1
+
+            if flag == INT_FLAG_CAS_TOKEN:
+                self.cas_token = int(header[pos:end])
+            elif flag == INT_FLAG_FETCHED:
+                self.fetched = int(header[pos:end])
+            elif flag == INT_FLAG_LAST_ACCESS:
+                self.last_access = int(header[pos:end])
+            elif flag == INT_FLAG_TTL:
+                self.ttl = int(header[pos:end])
+            elif flag == INT_FLAG_CLIENT_FLAG:
+                self.client_flag = int(header[pos:end])
+            elif flag == FLAG_WIN:
+                self.win = True
+            elif flag == FLAG_LOST:
+                self.win = False
+            elif flag == FLAG_STALE:
+                self.stale = True
+            elif flag == INT_FLAG_SIZE:
+                self.real_size = int(header[pos:end])
+            elif flag == TOKEN_FLAG_OPAQUE:
+                self.opaque = header[pos:end]
+            pos = end + 1
 
 
+# @dataclass(slots=True, init=False)
 @dataclass
 class Value(Success):
-    __slots__ = ("flags", "int_flags", "token_flags", "size", "value")
+    __slots__ = (
+        "cas_token",
+        "fetched",
+        "last_access",
+        "ttl",
+        "client_flag",
+        "win",
+        "stale",
+        "real_size",
+        "opaque",
+        "size",
+        "value",
+    )
     size: int
     value: Optional[Any]
 
     def __init__(
         self,
+        *,
         size: int,
         value: Optional[Any] = None,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        cas_token: Optional[int] = None,
+        fetched: Optional[int] = None,
+        last_access: Optional[int] = None,
+        ttl: Optional[int] = None,
+        client_flag: Optional[int] = None,
+        win: Optional[bool] = None,
+        stale: bool = False,
+        real_size: Optional[int] = None,
+        opaque: Optional[bytes] = None,
     ) -> None:
-        super().__init__(flags, int_flags, token_flags)
         self.size = size
         self.value = value
+        self.cas_token = cas_token
+        self.fetched = fetched
+        self.last_access = last_access
+        self.ttl = ttl
+        self.client_flag = client_flag
+        self.win = win
+        self.stale = stale
+        self.real_size = real_size
+        self.opaque = opaque
+
+    @classmethod
+    def from_header(cls, header: "Blob") -> "Value":
+        header_size = len(header)
+        if header_size < 4 or header[2] != SPACE:
+            raise ValueError(f"Invalid header {header!r}")
+        end = 4
+        while end < header_size:
+            if header[end] == SPACE:
+                break
+            end += 1
+        size = int(header[3:end])
+        result = cls(size=size)
+        result._set_flags(header, pos=end + 1)
+        return result
 
 
 @dataclass

--- a/tests/migrating_cache_client_test.py
+++ b/tests/migrating_cache_client_test.py
@@ -75,17 +75,13 @@ def _set_cache_client_mock_get_return_values(client: Mock, ttl: int = 10) -> Non
     client.meta_get.return_value = Value(
         size=3,
         value="bar",
-        flags=set(),
-        int_flags={IntFlag.TTL: ttl},
-        token_flags={},
+        ttl=ttl,
     )
     client.meta_multiget.return_value = {
         Key(key="foo", routing_key=None, is_unicode=False): Value(
             size=3,
             value="bar",
-            flags=set(),
-            int_flags={IntFlag.TTL: ttl},
-            token_flags={},
+            ttl=ttl,
         )
     }
 

--- a/tests/probabilistic_hot_cache_test.py
+++ b/tests/probabilistic_hot_cache_test.py
@@ -29,10 +29,8 @@ def client() -> Mock:
             return Value(
                 size=1,
                 value=1,
-                int_flags={
-                    IntFlag.HIT_AFTER_WRITE: 1,
-                    IntFlag.LAST_READ_AGE: 1,
-                },
+                fetched=1,
+                last_access=1,
             )
         elif key.key.endswith("miss"):
             return Miss()
@@ -40,10 +38,8 @@ def client() -> Mock:
             return Value(
                 size=1,
                 value=1,
-                int_flags={
-                    IntFlag.HIT_AFTER_WRITE: 1,
-                    IntFlag.LAST_READ_AGE: 9999,
-                },
+                fetched=1,
+                last_access=9999,
             )
 
     def meta_multiget(
@@ -643,10 +639,8 @@ def test_stale_expires(
     client.meta_get.side_effect = lambda *args, **kwargs: Value(
         size=1,
         value=1,
-        int_flags={
-            IntFlag.HIT_AFTER_WRITE: 1,
-            IntFlag.LAST_READ_AGE: 9999,
-        },
+        fetched=1,
+        last_access=9999,
     )
 
     # The item will no longer be in the hot cache


### PR DESCRIPTION
## Motivation / Description
We spent a lot of time tokenizing and then parsing the response flags.
This does the flag parsing in one single loop, speeding things up.
Also this rewrites response flags not to be Flags/IntFlags as they
can't be used for requests, and having them as part of the Value
dataclass speeds things up as well as simplifies the usage of the
library.

Before:
multithreaded: Overall: 151058.43 RPS / 6.62 us/req
singlethreaded: Overall: 151288.67 RPS / 6.61 us/req

After:
multithreaded: Overall: 193340.40 RPS / 5.17 us/req
singlethreaded: Overall: 193036.56 RPS / 5.18 us/req

Before:
![Screenshot 2023-11-06 at 12 31 56](https://github.com/RevenueCat/meta-memcache-py/assets/1917/897d11b1-51cc-47f0-bffc-8bada7060616)

After:
![Screenshot 2023-11-06 at 12 31 23](https://github.com/RevenueCat/meta-memcache-py/assets/1917/867fe6e0-4607-4211-b47e-b7d7f5732377)

## Changes introduced
- Avoid header tokenization phase
- Move flags to Success/Value class as attributes
- Move flag parsing to those classes.
