### PR TITLE
Fix poetry build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,14 @@
 [tool.poetry]
 name = "meta-memcache"
-version = "1.1.0"
+version = "1.1.1"
 description = "Modern, pure python, memcache client with support for new meta commands."
 license = "MIT"
 readme = "README.md"
 homepage = "https://github.com/RevenueCat/meta-memcache-py"
 repository = "https://github.com/RevenueCat/meta-memcache-py"
 authors = ["Guillermo Perez <bisho@revenuecat.com>"]
+packages = [{include = "meta_memcache", from="src"}]
+
 
 [tool.poetry.dependencies]
 python = "^3.8"

--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 from meta_memcache.cache_client import CacheClient
 from meta_memcache.configuration import (


### PR DESCRIPTION
When building the package poetry might wrongly
package the wrong way, with src/ prefix if
other files are present in the root folder.

Adding a packages setting on pyproject ensures
poetry won't get confused.
