### PR TITLE
rust build cmd

### DIFF
--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -40,6 +40,7 @@ from meta_memcache.protocol import (
     Miss,
     NotStored,
     ServerVersion,
+    ResponseFlags,
     SetMode,
     Success,
     TokenFlag,

--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -33,17 +33,15 @@ from meta_memcache.interfaces.router import (
 )
 from meta_memcache.protocol import (
     Conflict,
-    Flag,
-    IntFlag,
     Key,
     MetaCommand,
     Miss,
     NotStored,
     ServerVersion,
     ResponseFlags,
+    RequestFlags,
     SetMode,
     Success,
-    TokenFlag,
     Value,
 )
 from meta_memcache.routers.default import DefaultRouter

--- a/src/meta_memcache/cache_client.py
+++ b/src/meta_memcache/cache_client.py
@@ -1,4 +1,4 @@
-from typing import Callable, Iterable, Optional, Tuple
+from typing import Callable, Iterable, Optional
 
 from meta_memcache.base.base_cache_client import BaseCacheClient
 from meta_memcache.commands.high_level_commands import HighLevelCommandsMixin
@@ -25,7 +25,7 @@ class CacheClient(HighLevelCommandsMixin, MetaCommandsMixin, BaseCacheClient):
         servers: Iterable[ServerAddress],
         connection_pool_factory_fn: Callable[[ServerAddress], ConnectionPool],
         serializer: Optional[BaseSerializer] = None,
-        key_encoder_fn: Callable[[Key], Tuple[bytes, bool]] = default_key_encoder,
+        key_encoder_fn: Callable[[Key], bytes] = default_key_encoder,
         raise_on_server_error: bool = True,
     ) -> CacheApi:
         executor = DefaultExecutor(
@@ -48,7 +48,7 @@ class CacheClient(HighLevelCommandsMixin, MetaCommandsMixin, BaseCacheClient):
         gutter_ttl: int,
         connection_pool_factory_fn: Callable[[ServerAddress], ConnectionPool],
         serializer: Optional[BaseSerializer] = None,
-        key_encoder_fn: Callable[[Key], Tuple[bytes, bool]] = default_key_encoder,
+        key_encoder_fn: Callable[[Key], bytes] = default_key_encoder,
         raise_on_server_error: bool = True,
     ) -> CacheApi:
         executor = DefaultExecutor(
@@ -76,7 +76,7 @@ class CacheClient(HighLevelCommandsMixin, MetaCommandsMixin, BaseCacheClient):
         max_ttl: int,
         connection_pool_factory_fn: Callable[[ServerAddress], ConnectionPool],
         serializer: Optional[BaseSerializer] = None,
-        key_encoder_fn: Callable[[Key], Tuple[bytes, bool]] = default_key_encoder,
+        key_encoder_fn: Callable[[Key], bytes] = default_key_encoder,
         raise_on_server_error: bool = True,
     ) -> CacheApi:
         executor = DefaultExecutor(

--- a/src/meta_memcache/commands/high_level_commands.py
+++ b/src/meta_memcache/commands/high_level_commands.py
@@ -5,7 +5,6 @@ from typing import (
     Iterable,
     Optional,
     Protocol,
-    Set,
     Tuple,
     Type,
     TypeVar,
@@ -18,35 +17,33 @@ from meta_memcache.interfaces.high_level_commands import HighLevelCommandsProtoc
 from meta_memcache.interfaces.meta_commands import MetaCommandsProtocol
 from meta_memcache.interfaces.router import FailureHandling
 from meta_memcache.protocol import (
-    Flag,
-    IntFlag,
     Key,
     Miss,
     ReadResponse,
+    RequestFlags,
     SetMode,
     Success,
-    TokenFlag,
     Value,
+    MA_MODE_DEC,
 )
 
 T = TypeVar("T")
 _REFILL_FAILURE_HANDLING = FailureHandling(track_write_failures=False)
-
-DEFAULT_FLAGS: Set[Flag] = {
-    Flag.RETURN_VALUE,
-    Flag.RETURN_TTL,
-    Flag.RETURN_CLIENT_FLAG,
-    Flag.RETURN_LAST_ACCESS,
-    Flag.RETURN_FETCHED,
-}
-DEFAULT_CAS_FLAGS: Set[Flag] = {
-    Flag.RETURN_VALUE,
-    Flag.RETURN_TTL,
-    Flag.RETURN_CLIENT_FLAG,
-    Flag.RETURN_LAST_ACCESS,
-    Flag.RETURN_FETCHED,
-    Flag.RETURN_CAS_TOKEN,
-}
+DEFAULT_GET_FLAGS = RequestFlags(
+    return_value=True,
+    return_ttl=True,
+    return_client_flag=True,
+    return_last_access=True,
+    return_fetched=True,
+)
+DEFAULT_GET_CAS_FLAGS = RequestFlags(
+    return_value=True,
+    return_ttl=True,
+    return_client_flag=True,
+    return_last_access=True,
+    return_fetched=True,
+    return_cas_token=True,
+)
 
 
 class HighLevelCommandMixinWithMetaCommands(
@@ -83,7 +80,7 @@ class HighLevelCommandMixinWithMetaCommands(
         no_reply: bool = False,
         cas_token: Optional[int] = None,
         return_value: bool = False,
-    ) -> Tuple[Set[Flag], Dict[IntFlag, int], Dict[TokenFlag, bytes]]:
+    ) -> RequestFlags:
         ...  # pragma: no cover
 
 
@@ -99,28 +96,21 @@ class HighLevelCommandsMixin:
         set_mode: SetMode = SetMode.SET,
     ) -> bool:
         key = key if isinstance(key, Key) else Key(key)
-        flags: Set[Flag] = set()
+        flags = RequestFlags(cache_ttl=ttl)
         if no_reply:
-            flags.add(Flag.NOREPLY)
-        int_flags: Dict[IntFlag, int] = {
-            IntFlag.CACHE_TTL: ttl,
-        }
+            flags.no_reply = True
         if cas_token is not None:
-            int_flags[IntFlag.CAS_TOKEN] = cas_token
+            flags.cas_token = cas_token
             if stale_policy and stale_policy.mark_stale_on_cas_mismatch:
-                flags.add(Flag.MARK_STALE)
-        if set_mode == SetMode.SET:
-            token_flags = None
-        else:
-            token_flags = {TokenFlag.MODE: set_mode.value}
+                flags.mark_stale = True
+        if set_mode != SetMode.SET:
+            flags.mode = set_mode.value
 
         result = self.meta_set(
             key=key,
             value=value,
             ttl=ttl,
             flags=flags,
-            int_flags=int_flags,
-            token_flags=token_flags,
         )
 
         return isinstance(result, Success)
@@ -149,17 +139,18 @@ class HighLevelCommandsMixin:
            there is no need to track failures.
         """
         key = key if isinstance(key, Key) else Key(key)
-        flags: Set[Flag] = set()
+        flags = RequestFlags(
+            cache_ttl=ttl,
+            mode=SetMode.ADD.value,
+        )
         if no_reply:
-            flags.add(Flag.NOREPLY)
+            flags.no_reply = True
 
         result = self.meta_set(
             key=key,
             value=value,
             ttl=ttl,
             flags=flags,
-            int_flags={IntFlag.CACHE_TTL: ttl},
-            token_flags={TokenFlag.MODE: SetMode.ADD.value},
             failure_handling=_REFILL_FAILURE_HANDLING,
         )
 
@@ -179,21 +170,16 @@ class HighLevelCommandsMixin:
         it exists or not, use invalidate() instead.
         """
         key = key if isinstance(key, Key) else Key(key)
-        flags: Set[Flag] = set()
-        int_flags: Dict[IntFlag, int] = {}
+        flags = RequestFlags()
         if no_reply:
-            flags.add(Flag.NOREPLY)
+            flags.no_reply = True
         if cas_token is not None:
-            int_flags[IntFlag.CAS_TOKEN] = cas_token
+            flags.cas_token = cas_token
         if stale_policy and stale_policy.mark_stale_on_deletion_ttl > 0:
-            flags.add(Flag.MARK_STALE)
-            int_flags[IntFlag.CACHE_TTL] = stale_policy.mark_stale_on_deletion_ttl
+            flags.mark_stale = True
+            flags.cache_ttl = stale_policy.mark_stale_on_deletion_ttl
 
-        result = self.meta_delete(
-            key=key,
-            flags=flags,
-            int_flags=int_flags,
-        )
+        result = self.meta_delete(key=key, flags=flags)
 
         return isinstance(result, Success)
 
@@ -208,21 +194,16 @@ class HighLevelCommandsMixin:
         Returns true of the key deleted or it didn't exist anyway
         """
         key = key if isinstance(key, Key) else Key(key)
-        flags: Set[Flag] = set()
-        int_flags: Dict[IntFlag, int] = {}
+        flags = RequestFlags()
         if no_reply:
-            flags.add(Flag.NOREPLY)
+            flags.no_reply = True
         if cas_token is not None:
-            int_flags[IntFlag.CAS_TOKEN] = cas_token
+            flags.cas_token = cas_token
         if stale_policy and stale_policy.mark_stale_on_deletion_ttl > 0:
-            flags.add(Flag.MARK_STALE)
-            int_flags[IntFlag.CACHE_TTL] = stale_policy.mark_stale_on_deletion_ttl
+            flags.mark_stale = True
+            flags.cache_ttl = stale_policy.mark_stale_on_deletion_ttl
 
-        result = self.meta_delete(
-            key=key,
-            flags=flags,
-            int_flags=int_flags,
-        )
+        result = self.meta_delete(key=key, flags=flags)
 
         return isinstance(result, (Success, Miss))
 
@@ -233,11 +214,10 @@ class HighLevelCommandsMixin:
         no_reply: bool = False,
     ) -> bool:
         key = key if isinstance(key, Key) else Key(key)
-        flags: Set[Flag] = set()
-        int_flags = {IntFlag.CACHE_TTL: ttl}
+        flags = RequestFlags(cache_ttl=ttl)
         if no_reply:
-            flags.add(Flag.NOREPLY)
-        result = self.meta_get(key, flags=flags, int_flags=int_flags)
+            flags.no_reply = True
+        result = self.meta_get(key, flags=flags)
 
         return isinstance(result, Success)
 
@@ -346,22 +326,17 @@ class HighLevelCommandsMixin:
         return_cas_token: bool = False,
     ) -> Dict[Key, Optional[Value]]:
         if return_cas_token:
-            flags = DEFAULT_CAS_FLAGS.copy()
+            flags = DEFAULT_GET_CAS_FLAGS.copy()
         else:
-            flags = DEFAULT_FLAGS.copy()
-        if recache_policy is None and touch_ttl is None:
-            int_flags = None
-        else:
-            int_flags = {}
-            if recache_policy:
-                int_flags[IntFlag.RECACHE_TTL] = recache_policy.ttl
-            if touch_ttl is not None and touch_ttl >= 0:
-                int_flags[IntFlag.CACHE_TTL] = touch_ttl
+            flags = DEFAULT_GET_FLAGS.copy()
+        if recache_policy:
+            flags.recache_ttl = recache_policy.ttl
+        if touch_ttl is not None and touch_ttl >= 0:
+            flags.cache_ttl = touch_ttl
 
         results = self.meta_multiget(
             keys=[key if isinstance(key, Key) else Key(key) for key in keys],
             flags=flags,
-            int_flags=int_flags,
         )
         return {k: self._process_get_result(k, v) for k, v in results.items()}
 
@@ -392,21 +367,17 @@ class HighLevelCommandsMixin:
     ) -> Optional[Value]:
         key = key if isinstance(key, Key) else Key(key)
         if return_cas_token:
-            flags = DEFAULT_CAS_FLAGS.copy()
+            flags = DEFAULT_GET_CAS_FLAGS.copy()
         else:
-            flags = DEFAULT_FLAGS.copy()
-        if lease_policy is None and recache_policy is None and touch_ttl is None:
-            int_flags = None
-        else:
-            int_flags = {}
-            if lease_policy:
-                int_flags[IntFlag.MISS_LEASE_TTL] = lease_policy.ttl
-            if recache_policy:
-                int_flags[IntFlag.RECACHE_TTL] = recache_policy.ttl
-            if touch_ttl is not None and touch_ttl >= 0:
-                int_flags[IntFlag.CACHE_TTL] = touch_ttl
+            flags = DEFAULT_GET_FLAGS.copy()
+        if lease_policy:
+            flags.vivify_on_miss_ttl = lease_policy.ttl
+        if recache_policy:
+            flags.recache_ttl = recache_policy.ttl
+        if touch_ttl is not None and touch_ttl >= 0:
+            flags.cache_ttl = touch_ttl
 
-        result = self.meta_get(key, flags=flags, int_flags=int_flags)
+        result = self.meta_get(key, flags=flags)
         return self._process_get_result(key, result)
 
     def _process_get_result(
@@ -477,25 +448,22 @@ class HighLevelCommandsMixin:
         no_reply: bool = False,
         cas_token: Optional[int] = None,
         return_value: bool = False,
-    ) -> Tuple[Set[Flag], Dict[IntFlag, int], Dict[TokenFlag, bytes]]:
-        flags: Set[Flag] = set()
-        int_flags: Dict[IntFlag, int] = {
-            IntFlag.MA_DELTA_VALUE: abs(delta),
-        }
-        token_flags: Dict[TokenFlag, bytes] = {}
-
+    ) -> RequestFlags:
+        flags = RequestFlags(
+            ma_delta_value=abs(delta),
+        )
         if return_value:
-            flags.add(Flag.RETURN_VALUE)
+            flags.return_value = True
         if no_reply:
-            flags.add(Flag.NOREPLY)
+            flags.no_reply = True
         if refresh_ttl is not None:
-            int_flags[IntFlag.CACHE_TTL] = refresh_ttl
+            flags.cache_ttl = refresh_ttl
         if cas_token is not None:
-            int_flags[IntFlag.CAS_TOKEN] = cas_token
+            flags.cas_token = cas_token
         if delta < 0:
-            token_flags[TokenFlag.MODE] = b"-"
+            flags.mode = MA_MODE_DEC
 
-        return flags, int_flags, token_flags
+        return flags
 
     def delta(
         self: HighLevelCommandMixinWithMetaCommands,
@@ -506,15 +474,13 @@ class HighLevelCommandsMixin:
         cas_token: Optional[int] = None,
     ) -> bool:
         key = key if isinstance(key, Key) else Key(key)
-        flags, int_flags, token_flags = self._get_delta_flags(
+        flags = self._get_delta_flags(
             delta=delta,
             refresh_ttl=refresh_ttl,
             no_reply=no_reply,
             cas_token=cas_token,
         )
-        result = self.meta_arithmetic(
-            key=key, flags=flags, int_flags=int_flags, token_flags=token_flags
-        )
+        result = self.meta_arithmetic(key=key, flags=flags)
         return isinstance(result, Success)
 
     def delta_initialize(
@@ -528,17 +494,15 @@ class HighLevelCommandsMixin:
         cas_token: Optional[int] = None,
     ) -> bool:
         key = key if isinstance(key, Key) else Key(key)
-        flags, int_flags, token_flags = self._get_delta_flags(
+        flags = self._get_delta_flags(
             delta=delta,
             refresh_ttl=refresh_ttl,
             no_reply=no_reply,
             cas_token=cas_token,
         )
-        int_flags[IntFlag.MA_INITIAL_VALUE] = abs(initial_value)
-        int_flags[IntFlag.MISS_LEASE_TTL] = initial_ttl
-        result = self.meta_arithmetic(
-            key=key, flags=flags, int_flags=int_flags, token_flags=token_flags
-        )
+        flags.ma_initial_value = abs(initial_value)
+        flags.vivify_on_miss_ttl = initial_ttl
+        result = self.meta_arithmetic(key=key, flags=flags)
         return isinstance(result, Success)
 
     def delta_and_get(
@@ -549,15 +513,13 @@ class HighLevelCommandsMixin:
         cas_token: Optional[int] = None,
     ) -> Optional[int]:
         key = key if isinstance(key, Key) else Key(key)
-        flags, int_flags, token_flags = self._get_delta_flags(
+        flags = self._get_delta_flags(
             return_value=True,
             delta=delta,
             refresh_ttl=refresh_ttl,
             cas_token=cas_token,
         )
-        result = self.meta_arithmetic(
-            key=key, flags=flags, int_flags=int_flags, token_flags=token_flags
-        )
+        result = self.meta_arithmetic(key=key, flags=flags)
         if isinstance(result, Value):
             if isinstance(result.value, str) and result.value.isnumeric():
                 return int(result.value)
@@ -577,17 +539,15 @@ class HighLevelCommandsMixin:
         cas_token: Optional[int] = None,
     ) -> Optional[int]:
         key = key if isinstance(key, Key) else Key(key)
-        flags, int_flags, token_flags = self._get_delta_flags(
+        flags = self._get_delta_flags(
             return_value=True,
             delta=delta,
             refresh_ttl=refresh_ttl,
             cas_token=cas_token,
         )
-        int_flags[IntFlag.MA_INITIAL_VALUE] = abs(initial_value)
-        int_flags[IntFlag.MISS_LEASE_TTL] = initial_ttl
-        result = self.meta_arithmetic(
-            key=key, flags=flags, int_flags=int_flags, token_flags=token_flags
-        )
+        flags.ma_initial_value = abs(initial_value)
+        flags.vivify_on_miss_ttl = initial_ttl
+        result = self.meta_arithmetic(key=key, flags=flags)
         if isinstance(result, Value):
             if isinstance(result.value, str) and result.value.isnumeric():
                 return int(result.value)

--- a/src/meta_memcache/commands/high_level_commands.py
+++ b/src/meta_memcache/commands/high_level_commands.py
@@ -289,23 +289,23 @@ class HighLevelCommandsMixin:
 
             if isinstance(result, Value):
                 # It is a hit.
-                if result.win:
+                if result.flags.win:
                     # Win flag present, meaning we got the lease to
                     # recache/cache the item. We need to mimic a miss.
-                    return None, result.cas_token
-                if result.size == 0 and result.win is False:
+                    return None, result.flags.cas_token
+                if result.size == 0 and result.flags.win is False:
                     # The value is empty, this is a miss lease,
                     # and we lost, so we must keep retrying and
-                    # wait for the winner to populate the value.
+                    # wait for the.flags.winner to populate the value.
                     if i < lease_policy.miss_retries:
                         continue
                     else:
                         # We run out of retries, behave as a miss
-                        return None, result.cas_token
+                        return None, result.flags.cas_token
                 else:
                     # There is data, either the is no lease or
                     # we lost and should use the stale value.
-                    return result.value, result.cas_token
+                    return result.value, result.flags.cas_token
             else:
                 # With MISS_LEASE_TTL we should always get a value
                 # because on miss a lease empty value is generated
@@ -380,7 +380,7 @@ class HighLevelCommandsMixin:
         if result is None:
             return None, None
         else:
-            return result.value, result.cas_token
+            return result.value, result.flags.cas_token
 
     def _get(
         self: HighLevelCommandMixinWithMetaCommands,
@@ -416,7 +416,7 @@ class HighLevelCommandsMixin:
     ) -> Optional[Value]:
         if isinstance(result, Value):
             # It is a hit
-            if result.win:
+            if result.flags.win:
                 # Win flag present, meaning we got the lease to
                 # recache the item. We need to mimic a miss, so
                 # we set the value to None.

--- a/src/meta_memcache/commands/meta_commands.py
+++ b/src/meta_memcache/commands/meta_commands.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
 from meta_memcache.errors import MemcacheError
 from meta_memcache.interfaces.router import (
@@ -8,15 +8,13 @@ from meta_memcache.interfaces.router import (
 )
 from meta_memcache.protocol import (
     Conflict,
-    Flag,
-    IntFlag,
     Key,
     MetaCommand,
     Miss,
     NotStored,
     ReadResponse,
+    RequestFlags,
     Success,
-    TokenFlag,
     Value,
     ValueContainer,
     WriteResponse,
@@ -27,9 +25,7 @@ class MetaCommandsMixin:
     def meta_multiget(
         self: HasRouter,
         keys: List[Key],
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> Dict[Key, ReadResponse]:
         results: Dict[Key, ReadResponse] = {}
@@ -37,8 +33,6 @@ class MetaCommandsMixin:
             command=MetaCommand.META_GET,
             keys=keys,
             flags=flags,
-            int_flags=int_flags,
-            token_flags=token_flags,
             failure_handling=failure_handling,
         ).items():
             if not isinstance(result, (Miss, Value, Success)):
@@ -51,17 +45,13 @@ class MetaCommandsMixin:
     def meta_get(
         self: HasRouter,
         key: Key,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> ReadResponse:
         result = self.router.exec(
             command=MetaCommand.META_GET,
             key=key,
             flags=flags,
-            int_flags=int_flags,
-            token_flags=token_flags,
             failure_handling=failure_handling,
         )
         if not isinstance(result, (Miss, Value, Success)):
@@ -73,9 +63,7 @@ class MetaCommandsMixin:
         key: Key,
         value: Any,
         ttl: int,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         result = self.router.exec(
@@ -83,8 +71,6 @@ class MetaCommandsMixin:
             key=key,
             value=ValueContainer(value),
             flags=flags,
-            int_flags=int_flags,
-            token_flags=token_flags,
             failure_handling=failure_handling,
         )
         if not isinstance(result, (Success, NotStored, Conflict, Miss)):
@@ -94,17 +80,13 @@ class MetaCommandsMixin:
     def meta_delete(
         self: HasRouter,
         key: Key,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         result = self.router.exec(
             command=MetaCommand.META_DELETE,
             key=key,
             flags=flags,
-            int_flags=int_flags,
-            token_flags=token_flags,
             failure_handling=failure_handling,
         )
         if not isinstance(result, (Success, NotStored, Conflict, Miss)):
@@ -116,17 +98,13 @@ class MetaCommandsMixin:
     def meta_arithmetic(
         self: HasRouter,
         key: Key,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         result = self.router.exec(
             command=MetaCommand.META_ARITHMETIC,
             key=key,
             flags=flags,
-            int_flags=int_flags,
-            token_flags=token_flags,
             failure_handling=failure_handling,
         )
         if not isinstance(result, (Success, NotStored, Conflict, Miss, Value)):

--- a/src/meta_memcache/configuration.py
+++ b/src/meta_memcache/configuration.py
@@ -1,8 +1,7 @@
-import base64
 import hashlib
 import socket
 from enum import IntEnum
-from typing import Callable, Dict, Iterable, NamedTuple, Optional, Tuple
+from typing import Callable, Dict, Iterable, NamedTuple, Optional
 
 from meta_memcache.connection.pool import ConnectionPool
 from meta_memcache.protocol import Key, ServerVersion
@@ -157,17 +156,18 @@ class StalePolicy(NamedTuple):
     mark_stale_on_cas_mismatch: bool = False
 
 
-def default_key_encoder(key: Key) -> Tuple[bytes, bool]:
+def default_key_encoder(key: Key) -> bytes:
     """
     Generate valid memcache key as bytes for given Key.
     """
-    if key.is_unicode or len(key.key) > MAX_KEY_SIZE:
-        key_hash = hashlib.blake2b(key.key.encode(), digest_size=18).digest()
-        return base64.b64encode(key_hash), True
-    elif " " in key.key:
-        raise ValueError(f"Invalid key {key}")
-    else:
-        return key.key.encode("ascii"), False
+    # TODO: Support
+    # if isinstance(key.key, bytes):
+    #     data = key.key
+    # else:
+    data = key.key.encode()
+    if len(data) >= MAX_KEY_SIZE:
+        data = hashlib.blake2b(data, digest_size=18).digest()
+    return data
 
 
 class MigrationMode(IntEnum):

--- a/src/meta_memcache/executors/default.py
+++ b/src/meta_memcache/executors/default.py
@@ -17,6 +17,7 @@ from meta_memcache.protocol import (
     MetaCommand,
     Miss,
     NotStored,
+    ResponseFlags,
     ServerVersion,
     Success,
     TokenFlag,
@@ -252,12 +253,12 @@ class DefaultExecutor:
         Read response on a connection
         """
         if flags and Flag.NOREPLY in flags:
-            return Success()
+            return Success(flags=ResponseFlags())
         result = conn.get_response()
         if isinstance(result, Value):
             data = conn.get_value(result.size)
             if result.size > 0:
-                encoding_id = result.client_flag or 0
+                encoding_id = result.flags.client_flag or 0
                 try:
                     result.value = self._serializer.unserialize(data, encoding_id)
                 except Exception:

--- a/src/meta_memcache/extras/client_wrapper.py
+++ b/src/meta_memcache/extras/client_wrapper.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional
 
 from meta_memcache.commands.high_level_commands import HighLevelCommandsMixin
 from meta_memcache.configuration import ServerAddress
@@ -6,11 +6,9 @@ from meta_memcache.connection.pool import PoolCounters
 from meta_memcache.interfaces.router import FailureHandling, DEFAULT_FAILURE_HANDLING
 from meta_memcache.interfaces.cache_api import CacheApi
 from meta_memcache.protocol import (
-    Flag,
-    IntFlag,
     Key,
     ReadResponse,
-    TokenFlag,
+    RequestFlags,
     WriteResponse,
 )
 
@@ -33,32 +31,24 @@ class ClientWrapper(HighLevelCommandsMixin):
     def meta_multiget(
         self,
         keys: List[Key],
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> Dict[Key, ReadResponse]:
         return self.client.meta_multiget(
             keys=keys,
             flags=flags,
-            int_flags=int_flags,
-            token_flags=token_flags,
             failure_handling=failure_handling,
         )
 
     def meta_get(
         self,
         key: Key,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> ReadResponse:
         return self.client.meta_get(
             key=key,
             flags=flags,
-            int_flags=int_flags,
-            token_flags=token_flags,
             failure_handling=failure_handling,
         )
 
@@ -67,9 +57,7 @@ class ClientWrapper(HighLevelCommandsMixin):
         key: Key,
         value: Any,
         ttl: int,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         return self.client.meta_set(
@@ -77,40 +65,30 @@ class ClientWrapper(HighLevelCommandsMixin):
             value=value,
             ttl=ttl,
             flags=flags,
-            int_flags=int_flags,
-            token_flags=token_flags,
             failure_handling=failure_handling,
         )
 
     def meta_delete(
         self,
         key: Key,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         return self.client.meta_delete(
             key=key,
             flags=flags,
-            int_flags=int_flags,
-            token_flags=token_flags,
             failure_handling=failure_handling,
         )
 
     def meta_arithmetic(
         self,
         key: Key,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         return self.client.meta_arithmetic(
             key=key,
             flags=flags,
-            int_flags=int_flags,
-            token_flags=token_flags,
             failure_handling=failure_handling,
         )
 

--- a/src/meta_memcache/extras/migrating_cache_client.py
+++ b/src/meta_memcache/extras/migrating_cache_client.py
@@ -75,7 +75,11 @@ class MigratingCacheClient(HighLevelCommandsMixin):
             return current_mode
 
     def _get_value_ttl(self, value: Value) -> int:
-        ttl = value.ttl if value.ttl is not None else self._default_read_backfill_ttl
+        ttl = (
+            value.flags.ttl
+            if value.flags.ttl is not None
+            else self._default_read_backfill_ttl
+        )
         if ttl < 0:
             # TTL for items marked to store forvered is returned as -1
             ttl = 0

--- a/src/meta_memcache/extras/probabilistic_hot_cache.py
+++ b/src/meta_memcache/extras/probabilistic_hot_cache.py
@@ -124,10 +124,11 @@ class ProbabilisticHotCache(ClientWrapper):
         allowed: bool,
     ) -> None:
         if not is_hot:
-            hit_after_write = value.fetched or 0
-            last_read_age = value.last_access if value.last_access is not None else 9999
+            last_read_age = (
+                value.flags.last_access if value.flags.last_access is not None else 9999
+            )
             if (
-                hit_after_write > 0
+                value.flags.fetched
                 and last_read_age <= self._max_last_access_age_seconds
             ):
                 # Is detected as hot

--- a/src/meta_memcache/interfaces/executor.py
+++ b/src/meta_memcache/interfaces/executor.py
@@ -1,15 +1,14 @@
-from typing import Dict, List, Optional, Protocol, Set, Tuple
+from typing import Dict, List, Optional, Protocol, Tuple
+
 from meta_memcache.connection.pool import ConnectionPool
 from meta_memcache.events.write_failure_event import WriteFailureEvent
 
 from meta_memcache.protocol import (
-    Flag,
-    IntFlag,
     Key,
     MaybeValue,
     MemcacheResponse,
     MetaCommand,
-    TokenFlag,
+    RequestFlags,
 )
 
 
@@ -20,9 +19,7 @@ class Executor(Protocol):
         command: MetaCommand,
         key: Key,
         value: MaybeValue,
-        flags: Optional[Set[Flag]],
-        int_flags: Optional[Dict[IntFlag, int]],
-        token_flags: Optional[Dict[TokenFlag, bytes]],
+        flags: Optional[RequestFlags],
         track_write_failures: bool,
         raise_on_server_error: Optional[bool] = None,
     ) -> MemcacheResponse:
@@ -38,9 +35,7 @@ class Executor(Protocol):
         pool: ConnectionPool,
         command: MetaCommand,
         key_values: List[Tuple[Key, MaybeValue]],
-        flags: Optional[Set[Flag]],
-        int_flags: Optional[Dict[IntFlag, int]],
-        token_flags: Optional[Dict[TokenFlag, bytes]],
+        flags: Optional[RequestFlags],
         track_write_failures: bool,
         raise_on_server_error: Optional[bool] = None,
     ) -> Dict[Key, MemcacheResponse]:

--- a/src/meta_memcache/interfaces/meta_commands.py
+++ b/src/meta_memcache/interfaces/meta_commands.py
@@ -1,13 +1,11 @@
-from typing import Any, Dict, List, Optional, Protocol, Set
+from typing import Any, Dict, List, Optional, Protocol
 
 from meta_memcache.interfaces.router import FailureHandling, DEFAULT_FAILURE_HANDLING
 from meta_memcache.protocol import (
-    Flag,
-    IntFlag,
     Key,
     ReadResponse,
-    TokenFlag,
     WriteResponse,
+    RequestFlags,
 )
 
 
@@ -15,9 +13,7 @@ class MetaCommandsProtocol(Protocol):
     def meta_multiget(
         self,
         keys: List[Key],
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> Dict[Key, ReadResponse]:
         ...  # pragma: no cover
@@ -25,9 +21,7 @@ class MetaCommandsProtocol(Protocol):
     def meta_get(
         self,
         key: Key,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> ReadResponse:
         ...  # pragma: no cover
@@ -37,9 +31,7 @@ class MetaCommandsProtocol(Protocol):
         key: Key,
         value: Any,
         ttl: int,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         ...  # pragma: no cover
@@ -47,9 +39,7 @@ class MetaCommandsProtocol(Protocol):
     def meta_delete(
         self,
         key: Key,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         ...  # pragma: no cover
@@ -57,9 +47,7 @@ class MetaCommandsProtocol(Protocol):
     def meta_arithmetic(
         self,
         key: Key,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> WriteResponse:
         ...  # pragma: no cover

--- a/src/meta_memcache/interfaces/router.py
+++ b/src/meta_memcache/interfaces/router.py
@@ -1,17 +1,16 @@
-from typing import Dict, List, NamedTuple, Optional, Protocol, Set
+from typing import Dict, List, NamedTuple, Optional, Protocol
+
 
 from meta_memcache.configuration import ServerAddress
 from meta_memcache.connection.pool import PoolCounters
 from meta_memcache.interfaces.executor import Executor
 from meta_memcache.protocol import (
-    Flag,
-    IntFlag,
     Key,
     MaybeValue,
     MaybeValues,
     MemcacheResponse,
     MetaCommand,
-    TokenFlag,
+    RequestFlags,
 )
 
 
@@ -34,9 +33,7 @@ class Router(Protocol):
         command: MetaCommand,
         key: Key,
         value: MaybeValue = None,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> MemcacheResponse:
         """
@@ -52,9 +49,7 @@ class Router(Protocol):
         command: MetaCommand,
         keys: List[Key],
         values: MaybeValues = None,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> Dict[Key, MemcacheResponse]:
         """

--- a/src/meta_memcache/protocol.py
+++ b/src/meta_memcache/protocol.py
@@ -1,8 +1,19 @@
 from dataclasses import dataclass
 from enum import Enum, IntEnum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional, Union
 
-from meta_socket import ResponseFlags
+from meta_socket import (  # noqa: F401
+    ResponseFlags,
+    RequestFlags as RequestFlags,
+    SET_MODE_ADD,
+    SET_MODE_APPEND,
+    SET_MODE_PREPEND,
+    SET_MODE_REPLACE,
+    SET_MODE_SET,
+    MA_MODE_INC as MA_MODE_INC,
+    MA_MODE_DEC as MA_MODE_DEC,
+)
+
 
 ENDL = b"\r\n"
 NOOP: bytes = b"mn" + ENDL
@@ -39,57 +50,11 @@ class MetaCommand(Enum):
 
 
 class SetMode(Enum):
-    SET = b"S"  # Default
-    ADD = b"E"  # Add if item does NOT EXIST, else LRU bump and return NS
-    APPEND = b"A"  # If item exists, append the new value to its data.
-    PREPEND = b"P"  # If item exists, prepend the new value to its data.
-    REPLACE = b"R"  # Set only if item already exists.
-
-
-class Flag(Enum):
-    BINARY = b"b"
-    NOREPLY = b"q"
-    RETURN_CLIENT_FLAG = b"f"
-    RETURN_CAS_TOKEN = b"c"
-    RETURN_VALUE = b"v"
-    RETURN_TTL = b"t"
-    RETURN_SIZE = b"s"
-    RETURN_LAST_ACCESS = b"l"
-    RETURN_FETCHED = b"h"
-    RETURN_KEY = b"k"
-    NO_UPDATE_LRU = b"u"
-    MARK_STALE = b"I"
-
-
-class IntFlag(Enum):
-    CACHE_TTL = b"T"
-    RECACHE_TTL = b"R"
-    MISS_LEASE_TTL = b"N"
-    SET_CLIENT_FLAG = b"F"
-    MA_INITIAL_VALUE = b"J"
-    MA_DELTA_VALUE = b"D"
-    CAS_TOKEN = b"C"
-
-
-class TokenFlag(Enum):
-    OPAQUE = b"O"
-    # 'M' (mode switch):
-    # * Meta Arithmetic:
-    #  - I or +: increment
-    #  - D or -: decrement
-    # * Meta Set: See SetMode Enum above
-    #  - E: "add" command. LRU bump and return NS if item exists. Else add.
-    #  - A: "append" command. If item exists, append the new value to its data.
-    #  - P: "prepend" command. If item exists, prepend the new value to its data.
-    #  - R: "replace" command. Set only if item already exists.
-    #  - S: "set" command. The default mode, added for completeness.
-    MODE = b"M"
-
-
-# Store maps of byte values (int) to enum value
-flag_values: Dict[int, Flag] = {f.value[0]: f for f in Flag}
-int_flags_values: Dict[int, IntFlag] = {f.value[0]: f for f in IntFlag}
-token_flags_values: Dict[int, TokenFlag] = {f.value[0]: f for f in TokenFlag}
+    SET = SET_MODE_SET  # Default
+    ADD = SET_MODE_ADD  # Add if item does NOT EXIST, else LRU bump and return NS
+    APPEND = SET_MODE_APPEND  # If item exists, append the new value to its data.
+    PREPEND = SET_MODE_PREPEND  # If item exists, prepend the new value to its data.
+    REPLACE = SET_MODE_REPLACE  # Set only if item already exists.
 
 
 @dataclass
@@ -112,10 +77,6 @@ EMPTY_RESPONSE_FLAGS = ResponseFlags()
 class Success(MemcacheResponse):
     __slots__ = ("flags",)
     flags: ResponseFlags
-
-    @classmethod
-    def default(cls) -> "Success":
-        return cls(flags=ResponseFlags())
 
 
 @dataclass
@@ -168,10 +129,3 @@ def get_store_success_response_header(version: ServerVersion) -> bytes:
     if version == ServerVersion.AWS_1_6_6:
         return b"OK"
     return b"HD"
-
-
-def encode_size(size: int, version: ServerVersion) -> bytes:
-    if version == ServerVersion.AWS_1_6_6:
-        return b"S" + str(size).encode("ascii")
-    else:
-        return str(size).encode("ascii")

--- a/src/meta_memcache/routers/default.py
+++ b/src/meta_memcache/routers/default.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
-from typing import Callable, DefaultDict, Dict, List, Optional, Set, Tuple
+from typing import Callable, DefaultDict, Dict, List, Optional, Tuple
+
 
 from meta_memcache.configuration import ServerAddress
 from meta_memcache.connection.pool import ConnectionPool, PoolCounters
@@ -7,14 +8,12 @@ from meta_memcache.connection.providers import ConnectionPoolProvider
 from meta_memcache.interfaces.executor import Executor
 from meta_memcache.interfaces.router import DEFAULT_FAILURE_HANDLING, FailureHandling
 from meta_memcache.protocol import (
-    Flag,
-    IntFlag,
     Key,
     MaybeValue,
     MaybeValues,
     MemcacheResponse,
     MetaCommand,
-    TokenFlag,
+    RequestFlags,
 )
 
 
@@ -32,9 +31,7 @@ class DefaultRouter:
         command: MetaCommand,
         key: Key,
         value: MaybeValue = None,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> MemcacheResponse:
         """
@@ -49,8 +46,6 @@ class DefaultRouter:
             key=key,
             value=value,
             flags=flags,
-            int_flags=int_flags,
-            token_flags=token_flags,
             track_write_failures=failure_handling.track_write_failures,
             raise_on_server_error=failure_handling.raise_on_server_error,
         )
@@ -60,9 +55,7 @@ class DefaultRouter:
         command: MetaCommand,
         keys: List[Key],
         values: MaybeValues = None,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> Dict[Key, MemcacheResponse]:
         """
@@ -78,8 +71,6 @@ class DefaultRouter:
                     command=command,
                     key_values=key_values,
                     flags=flags,
-                    int_flags=int_flags,
-                    token_flags=token_flags,
                     track_write_failures=failure_handling.track_write_failures,
                     raise_on_server_error=failure_handling.raise_on_server_error,
                 )

--- a/src/meta_memcache/routers/ephemeral.py
+++ b/src/meta_memcache/routers/ephemeral.py
@@ -1,20 +1,18 @@
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional
 
 from meta_memcache.connection.providers import ConnectionPoolProvider
 from meta_memcache.interfaces.executor import Executor
 from meta_memcache.interfaces.router import DEFAULT_FAILURE_HANDLING, FailureHandling
 from meta_memcache.protocol import (
-    Flag,
-    IntFlag,
     Key,
     MaybeValue,
     MaybeValues,
     MemcacheResponse,
     MetaCommand,
-    TokenFlag,
+    RequestFlags,
 )
 from meta_memcache.routers.default import DefaultRouter
-from meta_memcache.routers.helpers import adjust_int_flags_for_max_ttl
+from meta_memcache.routers.helpers import adjust_flags_for_max_ttl
 
 
 class EphemeralRouter(DefaultRouter):
@@ -52,18 +50,14 @@ class EphemeralRouter(DefaultRouter):
         command: MetaCommand,
         key: Key,
         value: MaybeValue = None,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> MemcacheResponse:
         return super().exec(
             command=command,
             key=key,
             value=value,
-            flags=flags,
-            int_flags=adjust_int_flags_for_max_ttl(int_flags, self._max_ttl),
-            token_flags=token_flags,
+            flags=adjust_flags_for_max_ttl(flags, self._max_ttl),
             failure_handling=failure_handling,
         )
 
@@ -72,17 +66,13 @@ class EphemeralRouter(DefaultRouter):
         command: MetaCommand,
         keys: List[Key],
         values: MaybeValues = None,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> Dict[Key, MemcacheResponse]:
         return super().exec_multi(
             command=command,
             keys=keys,
             values=values,
-            flags=flags,
-            int_flags=adjust_int_flags_for_max_ttl(int_flags, self._max_ttl),
-            token_flags=token_flags,
+            flags=adjust_flags_for_max_ttl(flags, self._max_ttl),
             failure_handling=failure_handling,
         )

--- a/src/meta_memcache/routers/helpers.py
+++ b/src/meta_memcache/routers/helpers.py
@@ -1,23 +1,24 @@
-from typing import Dict, Optional
+from typing import Optional
 
-from meta_memcache.protocol import IntFlag
+from meta_memcache.protocol import RequestFlags
 
 
-def adjust_int_flags_for_max_ttl(
-    int_flags: Optional[Dict[IntFlag, int]],
+def _adjust_ttl(ttl: Optional[int], max_ttl: int) -> Optional[int]:
+    if ttl is not None and (ttl == 0 or ttl > max_ttl):
+        return max_ttl
+    return ttl
+
+
+def adjust_flags_for_max_ttl(
+    flags: Optional[RequestFlags],
     max_ttl: int,
-) -> Optional[Dict[IntFlag, int]]:
+) -> Optional[RequestFlags]:
     """
     Override TTLs > than `max_ttl`
     """
-    if int_flags:
-        for flag in (
-            IntFlag.CACHE_TTL,
-            IntFlag.RECACHE_TTL,
-            IntFlag.MISS_LEASE_TTL,
-        ):
-            ttl = int_flags.get(flag)
-            if ttl is not None and (ttl == 0 or ttl > max_ttl):
-                int_flags[flag] = max_ttl
+    if flags:
+        flags.cache_ttl = _adjust_ttl(flags.cache_ttl, max_ttl)
+        flags.recache_ttl = _adjust_ttl(flags.recache_ttl, max_ttl)
+        flags.vivify_on_miss_ttl = _adjust_ttl(flags.vivify_on_miss_ttl, max_ttl)
 
-    return int_flags
+    return flags

--- a/src/meta_memcache/settings.py
+++ b/src/meta_memcache/settings.py
@@ -5,4 +5,7 @@ DEFAULT_MARK_DOWN_PERIOD_S = 5.0
 
 DEFAULT_READ_BUFFER_SIZE = 4096
 
-MAX_KEY_SIZE = 250
+# Max key is 250, but when using binary keys will be b64 encoded
+# so take more space. Keys longer than this will be hashed, so
+# it's not a problem.
+MAX_KEY_SIZE = 187

--- a/tests/cache_client_test.py
+++ b/tests/cache_client_test.py
@@ -12,7 +12,7 @@ from meta_memcache import (
 )
 from meta_memcache.connection.pool import ConnectionPool, PoolCounters
 from meta_memcache.errors import MemcacheServerError
-from meta_memcache.protocol import NOOP, Flag, IntFlag
+from meta_memcache.protocol import NOOP, RequestFlags
 from meta_memcache.settings import DEFAULT_MARK_DOWN_PERIOD_S
 
 
@@ -167,10 +167,10 @@ def test_sharded_with_gutter_cache_client(mocker: MockerFixture) -> None:
 
     cache_client.meta_multiget(
         keys=[Key("bar"), Key("foo")],
-        flags={
-            Flag.NOREPLY,
-        },
-        int_flags={IntFlag.CACHE_TTL: 1000},
+        flags=RequestFlags(
+            no_reply=True,
+            cache_ttl=1000,
+        ),
     )
     get_pool.assert_has_calls([call(Key(key="bar")), call(Key(key="foo"))])
     get_gutter_pool.assert_called_once_with(Key("foo"))
@@ -194,10 +194,10 @@ def test_sharded_with_gutter_cache_client(mocker: MockerFixture) -> None:
 
     cache_client.meta_multiget(
         keys=[Key("bar"), Key("foo")],
-        flags={
-            Flag.NOREPLY,
-        },
-        int_flags={IntFlag.CACHE_TTL: 1000},
+        flags=RequestFlags(
+            no_reply=True,
+            cache_ttl=1000,
+        ),
     )
     get_pool.assert_has_calls([call(Key(key="bar")), call(Key(key="foo"))])
     get_gutter_pool.assert_called_once_with(Key("foo"))
@@ -220,10 +220,10 @@ def test_sharded_with_gutter_cache_client(mocker: MockerFixture) -> None:
 
     cache_client.meta_multiget(
         keys=[Key("bar"), Key("foo")],
-        flags={
-            Flag.NOREPLY,
-        },
-        int_flags={IntFlag.CACHE_TTL: 1000},
+        flags=RequestFlags(
+            no_reply=True,
+            cache_ttl=1000,
+        ),
     )
     get_pool.assert_has_calls([call(Key(key="bar")), call(Key(key="foo"))])
     get_gutter_pool.assert_not_called()

--- a/tests/ephemeral_cache_client_test.py
+++ b/tests/ephemeral_cache_client_test.py
@@ -1,5 +1,5 @@
 from unittest.mock import call
-from meta_memcache.protocol import NOOP, Flag, IntFlag
+from meta_memcache.protocol import NOOP, RequestFlags
 
 from pytest_mock import MockerFixture
 
@@ -29,10 +29,10 @@ def test_ephemeral_cache_client(mocker: MockerFixture) -> None:
 
     cache_client.meta_multiget(
         keys=[Key("bar"), Key("foo")],
-        flags={
-            Flag.NOREPLY,
-        },
-        int_flags={IntFlag.CACHE_TTL: 1000},
+        flags=RequestFlags(
+            no_reply=True,
+            cache_ttl=1000,
+        ),
     )
     c.sendall.assert_has_calls([call(b"mg bar q T60\r\n"), call(b"mg foo q T60\r\n")])
     c.sendall.reset_mock()

--- a/tests/memcache_socket_test.py
+++ b/tests/memcache_socket_test.py
@@ -67,11 +67,11 @@ def test_get_response(
     ms = MemcacheSocket(fake_socket)
     result = ms.get_response()
     assert isinstance(result, Success)
-    assert result.cas_token == 1
+    assert result.flags.cas_token == 1
 
     result = ms.get_response()
     assert isinstance(result, Value)
-    assert result.cas_token == 1
+    assert result.flags.cas_token == 1
     assert result.size == 2
 
 
@@ -84,11 +84,11 @@ def test_get_response_1_6_6(
     ms = MemcacheSocket(fake_socket, version=ServerVersion.AWS_1_6_6)
     result = ms.get_response()
     assert isinstance(result, Success)
-    assert result.cas_token == 1
+    assert result.flags.cas_token == 1
 
     result = ms.get_response()
     assert isinstance(result, Value)
-    assert result.cas_token == 1
+    assert result.flags.cas_token == 1
     assert result.size == 2
 
 
@@ -121,7 +121,7 @@ def test_get_value(
     ms = MemcacheSocket(fake_socket)
     result = ms.get_response()
     assert isinstance(result, Value)
-    assert result.cas_token == 1
+    assert result.flags.cas_token == 1
     assert result.size == 2
     ms.get_value(2)
 
@@ -135,9 +135,9 @@ def test_get_value_large(
     ms = MemcacheSocket(fake_socket, buffer_size=100)
     result = ms.get_response()
     assert isinstance(result, Value)
-    assert result.cas_token == 1
-    assert result.win is True
-    assert result.opaque == b"xxx"
+    assert result.flags.cas_token == 1
+    assert result.flags.win is True
+    assert bytes(result.flags.opaque) == b"xxx"
     assert result.size == 200
     value = ms.get_value(result.size)
     assert len(value) == result.size

--- a/tests/migrating_cache_client_test.py
+++ b/tests/migrating_cache_client_test.py
@@ -1,7 +1,15 @@
 from unittest.mock import Mock
 
 import pytest
-from meta_memcache import CacheClient, IntFlag, Key, SetMode, Value, WriteFailureEvent
+from meta_memcache import (
+    CacheClient,
+    IntFlag,
+    Key,
+    SetMode,
+    Value,
+    WriteFailureEvent,
+    ResponseFlags,
+)
 from meta_memcache.extras.migrating_cache_client import (
     MigratingCacheClient,
     MigrationMode,
@@ -74,13 +82,17 @@ def _set_cache_client_mock_get_return_values(client: Mock, ttl: int = 10) -> Non
     client.meta_get.return_value = Value(
         size=3,
         value="bar",
-        ttl=ttl,
+        flags=ResponseFlags(
+            ttl=ttl,
+        ),
     )
     client.meta_multiget.return_value = {
         Key(key="foo", routing_key=None, is_unicode=False): Value(
             size=3,
             value="bar",
-            ttl=ttl,
+            flags=ResponseFlags(
+                ttl=ttl,
+            ),
         )
     }
 

--- a/tests/migrating_cache_client_test.py
+++ b/tests/migrating_cache_client_test.py
@@ -3,12 +3,12 @@ from unittest.mock import Mock
 import pytest
 from meta_memcache import (
     CacheClient,
-    IntFlag,
     Key,
     SetMode,
     Value,
     WriteFailureEvent,
     ResponseFlags,
+    RequestFlags,
 )
 from meta_memcache.extras.migrating_cache_client import (
     MigratingCacheClient,
@@ -167,9 +167,7 @@ def test_migration_mode_origin_only(
         key=Key(key="foo", routing_key=None, is_unicode=False),
         value="bar",
         ttl=10,
-        flags=set(),
-        int_flags={IntFlag.CACHE_TTL: 10},
-        token_flags=None,
+        flags=RequestFlags(cache_ttl=10),
     )
     destination_client.meta_set.assert_not_called()
 
@@ -177,9 +175,7 @@ def test_migration_mode_origin_only(
     migration_client_origin_only.delete(key="foo")
     origin_client.meta_delete.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={},
-        token_flags=None,
+        flags=RequestFlags(),
     )
     destination_client.meta_delete.assert_not_called()
 
@@ -187,9 +183,7 @@ def test_migration_mode_origin_only(
     migration_client_origin_only.delta(key="foo", delta=1)
     origin_client.meta_arithmetic.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={IntFlag.MA_DELTA_VALUE: 1},
-        token_flags={},
+        flags=RequestFlags(ma_delta_value=1),
     )
     destination_client.meta_arithmetic.assert_not_called()
 
@@ -227,9 +221,7 @@ def test_migration_mode_destination_only(
         key=Key(key="foo", routing_key=None, is_unicode=False),
         value="bar",
         ttl=10,
-        flags=set(),
-        int_flags={IntFlag.CACHE_TTL: 10},
-        token_flags=None,
+        flags=RequestFlags(cache_ttl=10),
     )
 
     # Deletes
@@ -237,9 +229,7 @@ def test_migration_mode_destination_only(
     origin_client.meta_delete.assert_not_called()
     destination_client.meta_delete.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={},
-        token_flags=None,
+        flags=RequestFlags(),
     )
 
     # Arithmetic
@@ -247,9 +237,7 @@ def test_migration_mode_destination_only(
     origin_client.meta_arithmetic.assert_not_called()
     destination_client.meta_arithmetic.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={IntFlag.MA_DELTA_VALUE: 1},
-        token_flags={},
+        flags=RequestFlags(ma_delta_value=1),
     )
 
     # Touch
@@ -289,41 +277,31 @@ def test_migration_mode_populate_writes(
         key=Key(key="foo", routing_key=None, is_unicode=False),
         value="bar",
         ttl=10,
-        flags=set(),
-        int_flags={IntFlag.CACHE_TTL: 10},
-        token_flags=None,
+        flags=RequestFlags(cache_ttl=10),
     )
     destination_client.meta_set.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
         value="bar",
         ttl=10,
-        flags=set(),
-        int_flags={IntFlag.CACHE_TTL: 10},
-        token_flags=None,
+        flags=RequestFlags(cache_ttl=10),
     )
 
     # Deletes (both receive writes)
     migration_client.delete(key="foo")
     origin_client.meta_delete.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={},
-        token_flags=None,
+        flags=RequestFlags(),
     )
     destination_client.meta_delete.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={},
-        token_flags=None,
+        flags=RequestFlags(),
     )
 
     # Arithmetic
     migration_client.delta(key="foo", delta=1)
     origin_client.meta_arithmetic.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={IntFlag.MA_DELTA_VALUE: 1},
-        token_flags={},
+        flags=RequestFlags(ma_delta_value=1),
     )
     destination_client.meta_arithmetic.assert_not_called()
 
@@ -451,41 +429,31 @@ def test_migration_mode_populate_writes_and_reads_1pct(
         key=Key(key="foo", routing_key=None, is_unicode=False),
         value="bar",
         ttl=10,
-        flags=set(),
-        int_flags={IntFlag.CACHE_TTL: 10},
-        token_flags=None,
+        flags=RequestFlags(cache_ttl=10),
     )
     destination_client.meta_set.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
         value="bar",
         ttl=10,
-        flags=set(),
-        int_flags={IntFlag.CACHE_TTL: 10},
-        token_flags=None,
+        flags=RequestFlags(cache_ttl=10),
     )
 
     # Deletes (both receive writes)
     migration_client.delete(key="foo")
     origin_client.meta_delete.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={},
-        token_flags=None,
+        flags=RequestFlags(),
     )
     destination_client.meta_delete.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={},
-        token_flags=None,
+        flags=RequestFlags(),
     )
 
     # Arithmetic
     migration_client.delta(key="foo", delta=1)
     origin_client.meta_arithmetic.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={IntFlag.MA_DELTA_VALUE: 1},
-        token_flags={},
+        flags=RequestFlags(ma_delta_value=1),
     )
     destination_client.meta_arithmetic.assert_not_called()
 
@@ -566,41 +534,31 @@ def test_migration_mode_populate_writes_and_reads_10pct(
         key=Key(key="foo", routing_key=None, is_unicode=False),
         value="bar",
         ttl=10,
-        flags=set(),
-        int_flags={IntFlag.CACHE_TTL: 10},
-        token_flags=None,
+        flags=RequestFlags(cache_ttl=10),
     )
     destination_client.meta_set.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
         value="bar",
         ttl=10,
-        flags=set(),
-        int_flags={IntFlag.CACHE_TTL: 10},
-        token_flags=None,
+        flags=RequestFlags(cache_ttl=10),
     )
 
     # Deletes (both receive writes)
     migration_client.delete(key="foo")
     origin_client.meta_delete.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={},
-        token_flags=None,
+        flags=RequestFlags(),
     )
     destination_client.meta_delete.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={},
-        token_flags=None,
+        flags=RequestFlags(),
     )
 
     # Arithmetic
     migration_client.delta(key="foo", delta=1)
     origin_client.meta_arithmetic.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={IntFlag.MA_DELTA_VALUE: 1},
-        token_flags={},
+        flags=RequestFlags(ma_delta_value=1),
     )
     destination_client.meta_arithmetic.assert_not_called()
 
@@ -644,32 +602,24 @@ def test_migration_mode_use_destination_update_origin(
         key=Key(key="foo", routing_key=None, is_unicode=False),
         value="bar",
         ttl=10,
-        flags=set(),
-        int_flags={IntFlag.CACHE_TTL: 10},
-        token_flags=None,
+        flags=RequestFlags(cache_ttl=10),
     )
     destination_client.meta_set.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
         value="bar",
         ttl=10,
-        flags=set(),
-        int_flags={IntFlag.CACHE_TTL: 10},
-        token_flags=None,
+        flags=RequestFlags(cache_ttl=10),
     )
 
     # Deletes (both receive writes)
     migration_client.delete(key="foo")
     origin_client.meta_delete.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={},
-        token_flags=None,
+        flags=RequestFlags(),
     )
     destination_client.meta_delete.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={},
-        token_flags=None,
+        flags=RequestFlags(),
     )
 
     # Arithmetic
@@ -677,9 +627,7 @@ def test_migration_mode_use_destination_update_origin(
     origin_client.meta_arithmetic.assert_not_called()
     destination_client.meta_arithmetic.assert_called_once_with(
         key=Key(key="foo", routing_key=None, is_unicode=False),
-        flags=set(),
-        int_flags={IntFlag.MA_DELTA_VALUE: 1},
-        token_flags={},
+        flags=RequestFlags(ma_delta_value=1),
     )
 
     # Touch

--- a/tests/probabilistic_hot_cache_test.py
+++ b/tests/probabilistic_hot_cache_test.py
@@ -13,7 +13,7 @@ from meta_memcache.extras.probabilistic_hot_cache import (
     ProbabilisticHotCache,
 )
 from meta_memcache.metrics.prometheus import PrometheusMetricsCollector
-from meta_memcache.protocol import Flag, Miss, ReadResponse, TokenFlag
+from meta_memcache.protocol import Flag, Miss, ReadResponse, TokenFlag, ResponseFlags
 
 
 @pytest.fixture
@@ -29,8 +29,10 @@ def client() -> Mock:
             return Value(
                 size=1,
                 value=1,
-                fetched=1,
-                last_access=1,
+                flags=ResponseFlags(
+                    fetched=True,
+                    last_access=1,
+                ),
             )
         elif key.key.endswith("miss"):
             return Miss()
@@ -38,8 +40,10 @@ def client() -> Mock:
             return Value(
                 size=1,
                 value=1,
-                fetched=1,
-                last_access=9999,
+                flags=ResponseFlags(
+                    fetched=True,
+                    last_access=9999,
+                ),
             )
 
     def meta_multiget(
@@ -639,8 +643,10 @@ def test_stale_expires(
     client.meta_get.side_effect = lambda *args, **kwargs: Value(
         size=1,
         value=1,
-        fetched=1,
-        last_access=9999,
+        flags=ResponseFlags(
+            fetched=True,
+            last_access=9999,
+        ),
     )
 
     # The item will no longer be in the hot cache

--- a/tests/probabilistic_hot_cache_test.py
+++ b/tests/probabilistic_hot_cache_test.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional
 from unittest.mock import Mock
 
 from prometheus_client import CollectorRegistry
@@ -6,23 +6,21 @@ from meta_memcache.interfaces.router import DEFAULT_FAILURE_HANDLING, FailureHan
 
 import pytest
 
-from meta_memcache import CacheClient, IntFlag, Key, Value
+from meta_memcache import CacheClient, Key, Value
 from meta_memcache.errors import MemcacheError
 from meta_memcache.extras.probabilistic_hot_cache import (
     CachedValue,
     ProbabilisticHotCache,
 )
 from meta_memcache.metrics.prometheus import PrometheusMetricsCollector
-from meta_memcache.protocol import Flag, Miss, ReadResponse, TokenFlag, ResponseFlags
+from meta_memcache.protocol import Miss, ReadResponse, ResponseFlags, RequestFlags
 
 
 @pytest.fixture
 def client() -> Mock:
     def meta_get(
         key: Key,
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> ReadResponse:
         if key.key.endswith("hot"):
@@ -48,9 +46,7 @@ def client() -> Mock:
 
     def meta_multiget(
         keys: List[Key],
-        flags: Optional[Set[Flag]] = None,
-        int_flags: Optional[Dict[IntFlag, int]] = None,
-        token_flags: Optional[Dict[TokenFlag, bytes]] = None,
+        flags: Optional[RequestFlags] = None,
         failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
     ) -> Dict[Key, ReadResponse]:
         return {key: meta_get(key=key) for key in keys}
@@ -78,15 +74,13 @@ def random(monkeypatch) -> Mock:
 
 
 DEFAULT_FLAGS = {
-    "flags": {
-        Flag.RETURN_TTL,
-        Flag.RETURN_LAST_ACCESS,
-        Flag.RETURN_VALUE,
-        Flag.RETURN_FETCHED,
-        Flag.RETURN_CLIENT_FLAG,
-    },
-    "int_flags": None,
-    "token_flags": None,
+    "flags": RequestFlags(
+        return_ttl=True,
+        return_last_access=True,
+        return_value=True,
+        return_fetched=True,
+        return_client_flag=True,
+    ),
     "failure_handling": DEFAULT_FAILURE_HANDLING,
 }
 


### PR DESCRIPTION
- Add benchmark tool
- Add NonConsistentHashPoolProvider
- Copy prebuilt default flags
- Use namedtuples instead of tuples
- Do not use context manager for connection pool borrowing
- Refactor response flag parsing
- Implement response heading parsing in rust
- Build cmd in rust
