### PR TITLE
Update Python versions to include 3.14 and set as default

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -5,9 +5,9 @@ from nox import session, Session
 package = "meta_memcache"
 nox.options.sessions = "lint", "format", "check_version", "types", "tests"
 locations = "src", "tests", "noxfile.py", "benchmark.py"
-DEFAULT_VERSION = "3.11"
-DEFAULT_BENCHMARK_VERSIONS = ["3.12"]
-VERSIONS = ["3.13", "3.12", "3.11", "3.10"]
+DEFAULT_VERSION = "3.14"
+DEFAULT_BENCHMARK_VERSIONS = ["3.14"]
+VERSIONS = ["3.14", "3.13", "3.12", "3.11", "3.10"]
 
 # Default to uv backend:
 nox.options.default_venv_backend = "uv|virtualenv"


### PR DESCRIPTION
# 

- Setting Python 3.14 as the new default version (previously 3.11)
- Including Python 3.14 in the test suites (testing 3.10 - 3.14)