### PR TITLE
Copy flags object before modification to prevent mutation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
 authors = [{ name = "Guillermo Perez", email = "bisho@revenuecat.com" }]
 license = { text = "MIT License" }
 name = "meta-memcache"
-version = "2.1.0"
+version = "2.1.1"
 description = "Modern, pure python, memcache client with support for new meta commands."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 
 from meta_memcache.cache_client import CacheClient
 from meta_memcache.configuration import (

--- a/src/meta_memcache/routers/helpers.py
+++ b/src/meta_memcache/routers/helpers.py
@@ -17,6 +17,7 @@ def adjust_flags_for_max_ttl(
     Override TTLs > than `max_ttl`
     """
     if flags:
+        flags = flags.copy()
         flags.cache_ttl = _adjust_ttl(flags.cache_ttl, max_ttl)
         flags.recache_ttl = _adjust_ttl(flags.recache_ttl, max_ttl)
         flags.vivify_on_miss_ttl = _adjust_ttl(flags.vivify_on_miss_ttl, max_ttl)

--- a/uv.lock
+++ b/uv.lock
@@ -59,7 +59,7 @@ wheels = [
 
 [[package]]
 name = "meta-memcache"
-version = "2.1.0"
+version = "2.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "marisa-trie" },


### PR DESCRIPTION
This change prevents mutation of the original flags object in `adjust_flags_for_max_ttl` by creating a copy before modifying TTL values. Without this fix, the function would modify the input flags object directly, which could cause unintended side effects for callers who reuse the same flags object.