### PR TITLE
Add 7-day dependency cooldown via uv exclude-newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,11 @@ metrics = ["prometheus-client >= 0.17.1"]
 [project.urls]
 homepage = "https://github.com/RevenueCat/meta-memcache-py"
 
+[tool.uv]
+# Dependency cooldown: only resolve releases that are at least 7 days old.
+# Mitigates supply-chain risk from compromised fresh package versions.
+exclude-newer = "P7D"
+
 [tool.pytest.ini_options]
 addopts = "-ra"
 testpaths = ["tests"]

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 
+[options]
+exclude-newer = "2026-05-17T17:15:01.648757Z"
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "colorama"
 version = "0.4.6"
@@ -207,7 +211,7 @@ wheels = [
 
 [[package]]
 name = "meta-memcache"
-version = "2.1.1"
+version = "2.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "marisa-trie" },


### PR DESCRIPTION
Declares `tool.uv.exclude-newer = "P7D"` in pyproject.toml so `uv lock`
only resolves package versions that are at least 7 days old.

This mitigates supply-chain risk from compromised fresh releases (e.g.
typosquats, hijacked maintainer accounts) by giving the ecosystem a
window to detect and yank malicious versions before they enter our
lockfile.
