### PR TITLE
Add lease_wait_fn to customize lease retry waits

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,13 +370,17 @@ Invalidation...
         lease_policy: LeasePolicy,
         touch_ttl: Optional[int] = None,
         recache_policy: Optional[RecachePolicy] = None,
+        lease_wait_fn: Optional[Callable[[float], None]] = None,
     ) -> Optional[Any]:
         """
         Get a key. On miss try to get a lease.
 
         Guarantees only one cache client will get the miss and
         gets to repopulate cache, while the others are blocked
-        waiting (according to the settings in the LeasePolicy)
+        waiting (according to the settings in the LeasePolicy).
+
+        ``lease_wait_fn`` is invoked with the number of seconds to wait
+        between lease retries. Defaults to ``time.sleep``.
         """
 
     def get_or_lease_cas(
@@ -385,6 +389,7 @@ Invalidation...
         lease_policy: LeasePolicy,
         touch_ttl: Optional[int] = None,
         recache_policy: Optional[RecachePolicy] = None,
+        lease_wait_fn: Optional[Callable[[float], None]] = None,
     ) -> Tuple[Optional[Any], Optional[int]]:
         """
         Same as get_or_lease(), but also return the CAS token so

--- a/src/meta_memcache/commands/high_level_commands.py
+++ b/src/meta_memcache/commands/high_level_commands.py
@@ -1,6 +1,7 @@
 import time
 from typing import (
     Any,
+    Callable,
     Dict,
     Iterable,
     Optional,
@@ -236,6 +237,7 @@ class HighLevelCommandsMixin:
         lease_policy: LeasePolicy,
         touch_ttl: Optional[int] = None,
         recache_policy: Optional[RecachePolicy] = None,
+        lease_wait_fn: Optional[Callable[[float], None]] = None,
     ) -> Optional[Any]:
         """
         Get a key. On miss try to get a lease.
@@ -243,12 +245,16 @@ class HighLevelCommandsMixin:
         Guarantees only one cache client will get the miss and
         gets to repopulate cache, while the others are blocked
         waiting (according to the settings in the LeasePolicy)
+
+        ``lease_wait_fn`` is invoked with the number of seconds to wait
+        between lease retries. Defaults to ``time.sleep``.
         """
         value, _ = self.get_or_lease_cas(
             key=key,
             lease_policy=lease_policy,
             touch_ttl=touch_ttl,
             recache_policy=recache_policy,
+            lease_wait_fn=lease_wait_fn,
         )
         return value
 
@@ -258,6 +264,7 @@ class HighLevelCommandsMixin:
         lease_policy: LeasePolicy,
         touch_ttl: Optional[int] = None,
         recache_policy: Optional[RecachePolicy] = None,
+        lease_wait_fn: Optional[Callable[[float], None]] = None,
     ) -> Tuple[Optional[Any], Optional[int]]:
         """
         Same as get_or_lease(), but also return the CAS token so
@@ -267,10 +274,11 @@ class HighLevelCommandsMixin:
             raise ValueError(
                 "Wrong lease_policy: miss_retries needs to be greater than 0"
             )
+        wait = lease_wait_fn if lease_wait_fn is not None else time.sleep
         i = 0
         while True:
             if i > 0:
-                time.sleep(
+                wait(
                     min(
                         lease_policy.miss_max_retry_wait,
                         lease_policy.miss_retry_wait

--- a/src/meta_memcache/interfaces/high_level_commands.py
+++ b/src/meta_memcache/interfaces/high_level_commands.py
@@ -1,4 +1,15 @@
-from typing import Any, Dict, Iterable, Optional, Protocol, Tuple, Type, TypeVar, Union
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    Optional,
+    Protocol,
+    Tuple,
+    Type,
+    TypeVar,
+    Union,
+)
 
 from meta_memcache.configuration import LeasePolicy, RecachePolicy, StalePolicy
 from meta_memcache.protocol import Key, SetMode, Value
@@ -83,6 +94,7 @@ class HighLevelCommandsProtocol(Protocol):
         lease_policy: LeasePolicy,
         touch_ttl: Optional[int] = None,
         recache_policy: Optional[RecachePolicy] = None,
+        lease_wait_fn: Optional[Callable[[float], None]] = None,
     ) -> Optional[Any]: ...  # pragma: no cover
 
     def get_or_lease_cas(
@@ -91,6 +103,7 @@ class HighLevelCommandsProtocol(Protocol):
         lease_policy: LeasePolicy,
         touch_ttl: Optional[int] = None,
         recache_policy: Optional[RecachePolicy] = None,
+        lease_wait_fn: Optional[Callable[[float], None]] = None,
     ) -> Tuple[Optional[Any], Optional[int]]: ...  # pragma: no cover
 
     def get(

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -833,6 +833,32 @@ def test_get_or_lease_miss_runs_out_of_retries(
     )
 
 
+def test_get_or_lease_uses_custom_wait_fn(
+    wire_memcache_socket: WireSocket, wire_cache_client: CacheClient, time: MagicMock
+) -> None:
+    ws = wire_memcache_socket
+    cache_client = wire_cache_client
+    expected_cas_token = 123
+    # Two miss-lost (Z=loss), then a miss-win (W)
+    ws.queue_response(
+        b"VA 0 Z c122\r\n\r\n",
+        b"VA 0 Z c122\r\n\r\n",
+        b"VA 0 W c123\r\n\r\n",
+    )
+
+    custom_wait = MagicMock()
+    result, cas_token = cache_client.get_or_lease_cas(
+        key=Key("foo"),
+        lease_policy=LeasePolicy(),
+        lease_wait_fn=custom_wait,
+    )
+    assert result is None
+    assert cas_token == expected_cas_token
+    # time.sleep must not be called when a custom wait fn is provided
+    time.sleep.assert_not_called()
+    custom_wait.assert_has_calls([call(1.0), call(1.2)])
+
+
 def test_get_or_lease_errors(
     wire_memcache_socket: WireSocket, wire_cache_client: CacheClient
 ) -> None:


### PR DESCRIPTION
Adds an optional `lease_wait_fn: Callable[[float], None]` parameter to
`get_or_lease()` and `get_or_lease_cas()`. When provided, it is invoked
in place of `time.sleep` between lease retries.

The custom wait function can be used in tests (e.g., to mock time), to
integrate with `greenlet`-based frameworks (such as `gevent`) or to
limit wait concurrency.
