### PR TITLE
chore(ci): pin github actions to commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
       - name: Lint
         run: uv run --with nox -m nox -s lint
       - name: Format check
@@ -29,7 +29,7 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
       - name: Tests
         run: uv run --with nox -m nox -s tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: astral-sh/setup-uv@caf0cab7a618c569241d31dcd442f54681755d39 # v3.2.4
       - run: uv run --with nox -m nox
       - run: uv build
       - run: uv publish --token ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Pin third-party actions to full-length commit SHAs instead of mutable version tags to reduce supply-chain risk. Generated with pinact --min-age=7.

Thank you for contributing to meta-memcache-py. Before pressing the "Create Pull Request" button, please provide the following:

  - [ ] A description about what and why you are contributing, even if it's trivial.

  - [ ] The issue number(s) or PR number(s) in the description if you are contributing in response to those.

  - [ ] If applicable, unit tests.
