### PR TITLE
Fix typo in established connections field

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,8 +625,8 @@ class PoolCounters(NamedTuple):
     available: int
     # The # of connections active, currently in use, out of the pool
     active: int
-    # Current stablished connections (available + active)
-    stablished: int
+    # Current established connections (available + active)
+    established: int
     # Total # of connections created. If this keeps growing
     # might mean the pool size is too small and we are
     # constantly needing to create new connections:

--- a/src/meta_memcache/connection/pool.py
+++ b/src/meta_memcache/connection/pool.py
@@ -52,8 +52,8 @@ class PoolCounters(NamedTuple):
     available: int
     # The # of connections active, currently in use, out of the pool
     active: int
-    # Current stablished connections (available + active)
-    stablished: int
+    # Current established connections (available + active)
+    established: int
     # Total # of connections created. If this keeps growing
     # might meen the pool size is too small and we are
     # constantly needing to create new connections:
@@ -125,13 +125,13 @@ class ConnectionPool:
     def get_counters(self) -> PoolCounters:
         available = len(self._pool)
         total_created, total_destroyed = self._created, self._destroyed
-        stablished = total_created - total_destroyed
-        active = stablished - available
+        established = total_created - total_destroyed
+        active = established - available
 
         return PoolCounters(
             available=available,
             active=active,
-            stablished=stablished,
+            established=established,
             total_created=total_created,
             total_errors=self._errors,
         )

--- a/tests/cache_client_test.py
+++ b/tests/cache_client_test.py
@@ -132,7 +132,7 @@ def test_sharded_with_gutter_cache_client(
     assert connection_pool.get_counters() == PoolCounters(
         available=0,
         active=0,
-        stablished=0,
+        established=0,
         total_created=0,
         total_errors=1,  # The second conn is not attempted, marked down
     )
@@ -144,7 +144,7 @@ def test_sharded_with_gutter_cache_client(
     assert connection_pool.get_counters() == PoolCounters(
         available=2,
         active=0,
-        stablished=2,
+        established=2,
         total_created=2,
         total_errors=0,
     )


### PR DESCRIPTION
Fixing typo in field for established connections.
It's a public field, but I don't think it should be used often