### PR TITLE
Bump version to 2.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
 authors = [{ name = "Guillermo Perez", email = "bisho@revenuecat.com" }]
 license = { text = "MIT License" }
 name = "meta-memcache"
-version = "2.2.0"
+version = "2.3.0"
 description = "Modern, pure python, memcache client with support for new meta commands."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 
 from meta_memcache.cache_client import CacheClient
 from meta_memcache.configuration import (


### PR DESCRIPTION
Minor release: adds backward-compatible lease_wait_fn parameter to
get_or_lease()/get_or_lease_cas() (#89), plus the get_counters()
active-connection fix (#91) and CI/security hardening.
