### PR TITLE
Bump to version 2.4.0.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
 authors = [{ name = "Guillermo Perez", email = "bisho@revenuecat.com" }]
 license = { text = "MIT License" }
 name = "meta-memcache"
-version = "2.3.0"
+version = "2.4.0"
 description = "Modern, pure python, memcache client with support for new meta commands."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 
 from meta_memcache.cache_client import CacheClient
 from meta_memcache.configuration import (

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.10"
 
 [options]
-exclude-newer = "2026-05-17T17:15:01.648757Z"
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
 [[package]]
@@ -138,7 +138,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -211,7 +211,7 @@ wheels = [
 
 [[package]]
 name = "meta-memcache"
-version = "2.2.0"
+version = "2.4.0"
 source = { virtual = "." }
 dependencies = [
     { name = "marisa-trie" },


### PR DESCRIPTION
Contains:
* New `multi_get_cas` API - https://github.com/RevenueCat/meta-memcache-py/commit/9bba725b9b99df274840c7b452c214dd466a3bb1