### PR TITLE
Fix CI lint job.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -8,6 +8,7 @@ locations = "src", "tests", "noxfile.py", "benchmark.py"
 DEFAULT_VERSION = "3.14"
 DEFAULT_BENCHMARK_VERSIONS = ["3.14"]
 VERSIONS = ["3.14", "3.13", "3.12", "3.11", "3.10"]
+RUFF_VERSION = "0.16.1"
 
 # Default to uv backend:
 nox.options.default_venv_backend = "uv|virtualenv"
@@ -17,7 +18,7 @@ nox.options.default_venv_backend = "uv|virtualenv"
 def lint(session: Session) -> None:
     """Lint using ruff."""
     args = session.posargs or locations
-    session.install("ruff", ".")
+    session.install(f"ruff=={RUFF_VERSION}", ".")
     session.run("ruff", "check", *args)
 
 
@@ -25,14 +26,14 @@ def lint(session: Session) -> None:
 def format(session: Session) -> None:
     """Format check using ruff."""
     args = session.posargs or locations
-    session.run("uvx", "ruff", "format", "--diff", *args)
+    session.run("uvx", f"ruff@{RUFF_VERSION}", "format", "--diff", *args)
 
 
 @session(python=DEFAULT_VERSION)
 def fix_format(session: Session) -> None:
     """Fix format using ruff."""
     args = session.posargs or locations
-    session.run("uvx", "ruff", "format", *args)
+    session.run("uvx", f"ruff@{RUFF_VERSION}", "format", *args)
 
 
 @session(python=DEFAULT_VERSION)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,11 @@ show_missing = true
 [tool.ruff]
 line-length = 88
 
+[tool.ruff.lint]
+# Ruff 0.16 expanded the default rule set from 59 to 413 rules. Pin the selection
+# to the pre-0.16 default so version bumps don't silently add new rules.
+select = ["E4", "E7", "E9", "F"]
+
 [tool.ruff.lint.per-file-ignores]
 "tests/*.py" = ["E731"]
 "src/meta_memcache/__init__.py" = ["F401"]


### PR DESCRIPTION
CI was running on the newest release of ruff which can introduce breaking changes.

This PR:
* Pins `ruff` to a specific version.
* Limits checks what what existed pre-0.16.x.

0.16.x introduces hundreds of new rules (resulting in ~500 errors in this project). More details - https://astral.sh/blog/ruff-v0.16.0