### PR TITLE
Add set_cas() high level API

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,26 @@ Invalidation...
         Write a value using the specified `set_mode`
         """
 
+    def set_cas(
+        self,
+        key: Union[Key, str],
+        value: Any,
+        ttl: int,
+        cas_token: Optional[int] = None,
+        stale_policy: Optional[StalePolicy] = None,
+        set_mode: SetMode = SetMode.SET,  # Other are ADD, REPLACE, APPEND...
+    ) -> Optional[int]:
+        """
+        Same as set(), but also return the CAS token of the value
+        just written, so it can be used in following writes without
+        having to read the value back.
+
+        Returns None if the write was not successful.
+
+        Note `no_reply` is not supported, since the server needs to
+        reply for the CAS token to be returned.
+        """
+
     def refill(
         self: HighLevelCommandMixinWithMetaCommands,
         key: Union[Key, str],

--- a/src/meta_memcache/commands/high_level_commands.py
+++ b/src/meta_memcache/commands/high_level_commands.py
@@ -25,6 +25,7 @@ from meta_memcache.protocol import (
     SetMode,
     Success,
     Value,
+    WriteResponse,
     MA_MODE_DEC,
 )
 
@@ -58,6 +59,18 @@ class HighLevelCommandMixinWithMetaCommands(
         recache_policy: Optional[RecachePolicy] = None,
         return_cas_token: bool = False,
     ) -> Optional[Value]: ...  # pragma: no cover
+
+    def _set(
+        self,
+        key: Union[Key, str],
+        value: Any,
+        ttl: int,
+        no_reply: bool = False,
+        cas_token: Optional[int] = None,
+        stale_policy: Optional[StalePolicy] = None,
+        set_mode: SetMode = SetMode.SET,
+        return_cas_token: bool = False,
+    ) -> WriteResponse: ...  # pragma: no cover
 
     def _process_get_result(
         self, key: Union[Key, str], result: ReadResponse
@@ -97,10 +110,65 @@ class HighLevelCommandsMixin:
         """
         Write a value using the specified `set_mode`
         """
+        result = self._set(
+            key=key,
+            value=value,
+            ttl=ttl,
+            no_reply=no_reply,
+            cas_token=cas_token,
+            stale_policy=stale_policy,
+            set_mode=set_mode,
+        )
+
+        return isinstance(result, Success)
+
+    def set_cas(
+        self: HighLevelCommandMixinWithMetaCommands,
+        key: Union[Key, str],
+        value: Any,
+        ttl: int,
+        cas_token: Optional[int] = None,
+        stale_policy: Optional[StalePolicy] = None,
+        set_mode: SetMode = SetMode.SET,
+    ) -> Optional[int]:
+        """
+        Same as set(), but also return the CAS token of the value
+        just written, so it can be used in following writes without
+        having to read the value back.
+
+        Returns None if the write was not successful.
+
+        Note `no_reply` is not supported, since the server needs to
+        reply for the CAS token to be returned.
+        """
+        result = self._set(
+            key=key,
+            value=value,
+            ttl=ttl,
+            cas_token=cas_token,
+            stale_policy=stale_policy,
+            set_mode=set_mode,
+            return_cas_token=True,
+        )
+
+        return result.flags.cas_token if isinstance(result, Success) else None
+
+    def _set(
+        self: HighLevelCommandMixinWithMetaCommands,
+        key: Union[Key, str],
+        value: Any,
+        ttl: int,
+        no_reply: bool = False,
+        cas_token: Optional[int] = None,
+        stale_policy: Optional[StalePolicy] = None,
+        set_mode: SetMode = SetMode.SET,
+        return_cas_token: bool = False,
+    ) -> WriteResponse:
         key = key if isinstance(key, Key) else Key(key)
         flags = RequestFlags(
             cache_ttl=ttl,
             no_reply=no_reply,
+            return_cas_token=return_cas_token,
             cas_token=cas_token,
             mark_stale=bool(
                 cas_token is not None
@@ -110,14 +178,12 @@ class HighLevelCommandsMixin:
             mode=set_mode.value if set_mode != SetMode.SET else None,
         )
 
-        result = self.meta_set(
+        return self.meta_set(
             key=key,
             value=value,
             ttl=ttl,
             flags=flags,
         )
-
-        return isinstance(result, Success)
 
     def refill(
         self: HighLevelCommandMixinWithMetaCommands,

--- a/src/meta_memcache/interfaces/high_level_commands.py
+++ b/src/meta_memcache/interfaces/high_level_commands.py
@@ -12,7 +12,7 @@ from typing import (
 )
 
 from meta_memcache.configuration import LeasePolicy, RecachePolicy, StalePolicy
-from meta_memcache.protocol import Key, SetMode, Value
+from meta_memcache.protocol import Key, SetMode, Value, WriteResponse
 
 T = TypeVar("T")
 
@@ -28,6 +28,39 @@ class HighLevelCommandsProtocol(Protocol):
         stale_policy: Optional[StalePolicy] = None,
         set_mode: SetMode = SetMode.SET,
     ) -> bool: ...  # pragma: no cover
+
+    def set_cas(
+        self,
+        key: Union[Key, str],
+        value: Any,
+        ttl: int,
+        cas_token: Optional[int] = None,
+        stale_policy: Optional[StalePolicy] = None,
+        set_mode: SetMode = SetMode.SET,
+    ) -> Optional[int]:
+        """
+        Same as set(), but also return the CAS token of the value
+        just written, so it can be used in following writes without
+        having to read the value back.
+
+        Returns None if the write was not successful.
+
+        Note `no_reply` is not supported, since the server needs to
+        reply for the CAS token to be returned.
+        """
+        ...  # pragma: no cover
+
+    def _set(
+        self,
+        key: Union[Key, str],
+        value: Any,
+        ttl: int,
+        no_reply: bool = False,
+        cas_token: Optional[int] = None,
+        stale_policy: Optional[StalePolicy] = None,
+        set_mode: SetMode = SetMode.SET,
+        return_cas_token: bool = False,
+    ) -> WriteResponse: ...  # pragma: no cover
 
     def refill(
         self,

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -266,6 +266,68 @@ def test_set_cmd(
     ws.assert_wire(b"ms foo 3 I T300 F16 C666\r\n123\r\n")
 
 
+def test_set_cas_cmd(
+    wire_memcache_socket: WireSocket,
+    wire_cache_client: CacheClient,
+) -> None:
+    ws = wire_memcache_socket
+    cache_client = wire_cache_client
+
+    # str key -> c flag requesting the CAS token back
+    cache_client.set_cas(key="foo", value="bar", ttl=300)
+    ws.assert_wire(b"ms foo 3 c T300 F0\r\nbar\r\n")
+
+    # SetMode.ADD -> ME
+    cache_client.set_cas(key=Key("foo"), value=123, ttl=300, set_mode=SetMode.ADD)
+    ws.assert_wire(b"ms foo 3 c T300 F2 ME\r\n123\r\n")
+
+    # cas_token + stale_policy(mark_stale_on_cas_mismatch=True) -> I flag
+    cache_client.set_cas(
+        key=Key("foo"),
+        value=b"123",
+        ttl=300,
+        cas_token=666,
+        stale_policy=StalePolicy(mark_stale_on_cas_mismatch=True),
+    )
+    ws.assert_wire(b"ms foo 3 c I T300 F16 C666\r\n123\r\n")
+
+
+def test_set_cas_returns_token(
+    wire_memcache_socket: WireSocket,
+    wire_cache_client: CacheClient,
+) -> None:
+    ws = wire_memcache_socket
+    cache_client = wire_cache_client
+
+    # Server returns the CAS token of the value just written
+    ws.queue_response(b"HD c123\r\n")
+    assert cache_client.set_cas(key="foo", value="bar", ttl=300) == 123
+
+    # Success without a CAS token (server didn't return it)
+    ws.queue_response(b"HD\r\n")
+    assert cache_client.set_cas(key="foo", value="bar", ttl=300) is None
+
+    # Failed write (NS: not stored, i.e. CAS mismatch or ADD on existing key)
+    ws.queue_response(b"NS\r\n")
+    assert cache_client.set_cas(key="foo", value="bar", ttl=300, cas_token=666) is None
+
+
+def test_set_cas_success_fail(
+    memcache_socket: MemcacheSocket,
+    cache_client: CacheClient,
+) -> None:
+    memcache_socket.meta_set.return_value = Success(
+        flags=ResponseFlags(cas_token=123),
+    )
+    assert cache_client.set_cas(key=Key("foo"), value="bar", ttl=300) == 123
+
+    memcache_socket.meta_set.return_value = Success(flags=ResponseFlags())
+    assert cache_client.set_cas(key=Key("foo"), value="bar", ttl=300) is None
+
+    memcache_socket.meta_set.return_value = NotStored()
+    assert cache_client.set_cas(key=Key("foo"), value="bar", ttl=300) is None
+
+
 def test_set_cmd_1_6_6(
     wire_memcache_socket_1_6_6: WireSocket,
     wire_cache_client_1_6_6: CacheClient,


### PR DESCRIPTION
When using compare and swap, clients store the cas token of keys on reads, and use `set()` with `cas_token` argument when writting back.  
  
Normally a client should not write the same key twice, but if they need to, long running jobs or complex use-cases, being able to get the updated cas after the set is handy.