### PR TITLE
feat: Implement get_or_lease in probabilistic hot cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
 authors = [{ name = "Guillermo Perez", email = "bisho@revenuecat.com" }]
 license = { text = "MIT License" }
 name = "meta-memcache"
-version = "2.4.0"
+version = "2.5.0"
 description = "Modern, pure python, memcache client with support for new meta commands."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/meta_memcache/__init__.py
+++ b/src/meta_memcache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.4.0"
+__version__ = "2.5.0"
 
 from meta_memcache.cache_client import CacheClient
 from meta_memcache.configuration import (

--- a/src/meta_memcache/commands/high_level_commands.py
+++ b/src/meta_memcache/commands/high_level_commands.py
@@ -18,6 +18,7 @@ from meta_memcache.interfaces.high_level_commands import HighLevelCommandsProtoc
 from meta_memcache.interfaces.meta_commands import MetaCommandsProtocol
 from meta_memcache.interfaces.router import FailureHandling
 from meta_memcache.protocol import (
+    MA_MODE_DEC,
     Key,
     Miss,
     ReadResponse,
@@ -25,7 +26,6 @@ from meta_memcache.protocol import (
     SetMode,
     Success,
     Value,
-    MA_MODE_DEC,
 )
 
 T = TypeVar("T")
@@ -57,6 +57,15 @@ class HighLevelCommandMixinWithMetaCommands(
         lease_policy: Optional[LeasePolicy] = None,
         recache_policy: Optional[RecachePolicy] = None,
         return_cas_token: bool = False,
+    ) -> Optional[Value]: ...  # pragma: no cover
+
+    def _get_or_lease(
+        self,
+        key: Union[Key, str],
+        lease_policy: LeasePolicy,
+        touch_ttl: Optional[int] = None,
+        recache_policy: Optional[RecachePolicy] = None,
+        lease_wait_fn: Optional[Callable[[float], None]] = None,
     ) -> Optional[Value]: ...  # pragma: no cover
 
     def _process_get_result(
@@ -249,14 +258,14 @@ class HighLevelCommandsMixin:
         ``lease_wait_fn`` is invoked with the number of seconds to wait
         between lease retries. Defaults to ``time.sleep``.
         """
-        value, _ = self.get_or_lease_cas(
+        result = self._get_or_lease(
             key=key,
             lease_policy=lease_policy,
             touch_ttl=touch_ttl,
             recache_policy=recache_policy,
             lease_wait_fn=lease_wait_fn,
         )
-        return value
+        return result.value if result is not None else None
 
     def get_or_lease_cas(
         self: HighLevelCommandMixinWithMetaCommands,
@@ -269,6 +278,35 @@ class HighLevelCommandsMixin:
         """
         Same as get_or_lease(), but also return the CAS token so
         it can be used during writes and detect races
+        """
+        result = self._get_or_lease(
+            key=key,
+            lease_policy=lease_policy,
+            touch_ttl=touch_ttl,
+            recache_policy=recache_policy,
+            lease_wait_fn=lease_wait_fn,
+        )
+        if result is None:
+            return None, None
+        return result.value, result.flags.cas_token
+
+    def _get_or_lease(
+        self: HighLevelCommandMixinWithMetaCommands,
+        key: Union[Key, str],
+        lease_policy: LeasePolicy,
+        touch_ttl: Optional[int] = None,
+        recache_policy: Optional[RecachePolicy] = None,
+        lease_wait_fn: Optional[Callable[[float], None]] = None,
+    ) -> Optional[Value]:
+        """
+        Internal version of get_or_lease() that returns the raw Value, so
+        wrappers can inspect the response flags, i.e. to decide whether the
+        value is worth promoting into a local cache, or read the CAS token.
+
+        `Value.value` is None when the caller must behave as if this was a
+        miss: either it won the lease, or it lost and ran out of retries.
+        The Value itself is still returned in both cases, since the lease
+        winner needs its CAS token to write the value back.
         """
         if lease_policy.miss_retries <= 0:
             raise ValueError(
@@ -295,29 +333,24 @@ class HighLevelCommandsMixin:
                 return_cas_token=True,
             )
 
-            if isinstance(result, Value):
-                # It is a hit.
-                if result.flags.win:
-                    # Win flag present, meaning we got the lease to
-                    # recache/cache the item. We need to mimic a miss.
-                    return None, result.flags.cas_token
-                if result.size == 0 and result.flags.win is False:
-                    # The value is empty, this is a miss lease,
-                    # and we lost, so we must keep retrying and
-                    # wait for the.flags.winner to populate the value.
-                    if i < lease_policy.miss_retries:
-                        continue
-                    else:
-                        # We run out of retries, behave as a miss
-                        return None, result.flags.cas_token
-                else:
-                    # There is data, either the is no lease or
-                    # we lost and should use the stale value.
-                    return result.value, result.flags.cas_token
-            else:
+            if not isinstance(result, Value):
                 # With MISS_LEASE_TTL we should always get a value
                 # because on miss a lease empty value is generated
                 raise MemcacheError(f"Unexpected response: {result} for key {key}")
+
+            if (
+                result.size == 0
+                and result.flags.win is False
+                and i < lease_policy.miss_retries
+            ):
+                # This is a miss lease and we lost, so we must keep retrying
+                # and wait for the winner to populate the value.
+                continue
+
+            # Either there is data, or we got a placeholder: we won the lease,
+            # or we lost and ran out of retries. _process_get_result() already
+            # cleared the value of the placeholders, so both behave as a miss.
+            return result
 
     def get(
         self: HighLevelCommandMixinWithMetaCommands,
@@ -443,6 +476,11 @@ class HighLevelCommandsMixin:
                 # Win flag present, meaning we got the lease to
                 # recache the item. We need to mimic a miss, so
                 # we set the value to None.
+                result.value = None
+            elif result.size == 0 and result.flags.win is False:
+                # An empty value with a lose flag is the placeholder the
+                # server plants on a lease miss, while the winner
+                # repopulates it. There is no value to return either.
                 result.value = None
             return result
         elif isinstance(result, Miss):

--- a/src/meta_memcache/extras/probabilistic_hot_cache.py
+++ b/src/meta_memcache/extras/probabilistic_hot_cache.py
@@ -1,13 +1,13 @@
+import pickle
 import random
 import threading
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
-import pickle
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 from marisa_trie import Trie  # type: ignore
 
-from meta_memcache.configuration import RecachePolicy
+from meta_memcache.configuration import LeasePolicy, RecachePolicy
 from meta_memcache.extras.client_wrapper import ClientWrapper
 from meta_memcache.interfaces.cache_api import CacheApi
 from meta_memcache.metrics.base import BaseMetricsCollector, MetricDefinition
@@ -192,6 +192,39 @@ class ProbabilisticHotCache(ClientWrapper):
         touch_ttl: Optional[int] = None,
         recache_policy: Optional[RecachePolicy] = None,
     ) -> Optional[Any]:
+        return self._hot_cache_get(
+            key=key,
+            touch_ttl=touch_ttl,
+            recache_policy=recache_policy,
+        )
+
+    def get_or_lease(
+        self,
+        key: Union[Key, str],
+        lease_policy: LeasePolicy,
+        touch_ttl: Optional[int] = None,
+        recache_policy: Optional[RecachePolicy] = None,
+        lease_wait_fn: Optional[Callable[[float], None]] = None,
+    ) -> Optional[Any]:
+        # A hot cache hit needs no lease: the value is already local and there
+        # is nothing to repopulate. Only the requests that fall through to the
+        # server take part in the lease.
+        return self._hot_cache_get(
+            key=key,
+            touch_ttl=touch_ttl,
+            recache_policy=recache_policy,
+            lease_policy=lease_policy,
+            lease_wait_fn=lease_wait_fn,
+        )
+
+    def _hot_cache_get(
+        self,
+        key: Union[Key, str],
+        touch_ttl: Optional[int] = None,
+        recache_policy: Optional[RecachePolicy] = None,
+        lease_policy: Optional[LeasePolicy] = None,
+        lease_wait_fn: Optional[Callable[[float], None]] = None,
+    ) -> Optional[Any]:
         key = key if isinstance(key, Key) else Key(key)
         if self._allowed_prefixes and not self._allowed_prefixes.prefixes(key.key):
             is_hot = False
@@ -203,12 +236,26 @@ class ProbabilisticHotCache(ClientWrapper):
             if found:
                 return value
 
-        result = self._get(
-            key=key,
-            touch_ttl=touch_ttl,
-            recache_policy=recache_policy,
-            return_cas_token=False,
-        )
+        if lease_policy is not None:
+            result = self._get_or_lease(
+                key=key,
+                lease_policy=lease_policy,
+                touch_ttl=touch_ttl,
+                recache_policy=recache_policy,
+                lease_wait_fn=lease_wait_fn,
+            )
+            if result and result.value is None:
+                # Lease placeholder: we hold the lease, or we lost and ran out
+                # of retries. Behaves as a miss, and nothing worth promoting.
+                result = None
+        else:
+            result = self._get(
+                key=key,
+                touch_ttl=touch_ttl,
+                recache_policy=recache_policy,
+                return_cas_token=False,
+            )
+
         if result is None:
             allowed and self._metrics and self._metrics.metric_inc("candidate_misses")
             is_hot and self._clear_hot_cache_if_necessary(key)

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -694,6 +694,22 @@ def test_recache_lost_returns_stale_value(
     assert cas_token == expected_cas_token
 
 
+def test_get_empty_value_is_not_a_lease_placeholder(
+    wire_memcache_socket: WireSocket, wire_cache_client: CacheClient
+) -> None:
+    ws = wire_memcache_socket
+    cache_client = wire_cache_client
+
+    # A zero-sized value is only a lease placeholder when the server also
+    # flags it as lost (Z). Without the flag it is just an empty value.
+    encoded_value = MixedSerializer().serialize(Key("foo"), b"")
+    assert len(encoded_value.data) == 0
+    ws.queue_response(b"VA 0 f" + str(encoded_value.encoding_id).encode() + b"\r\n\r\n")
+
+    assert cache_client.get(key=Key("foo")) == b""
+    ws.assert_wire(b"mg foo f v t l h\r\n")
+
+
 def test_get_or_lease_hit(
     wire_memcache_socket: WireSocket, wire_cache_client: CacheClient, time: MagicMock
 ) -> None:

--- a/tests/probabilistic_hot_cache_test.py
+++ b/tests/probabilistic_hot_cache_test.py
@@ -7,6 +7,7 @@ from meta_memcache.interfaces.router import DEFAULT_FAILURE_HANDLING, FailureHan
 import pytest
 
 from meta_memcache import CacheClient, Key, Value
+from meta_memcache.configuration import LeasePolicy
 from meta_memcache.errors import MemcacheError
 from meta_memcache.extras.probabilistic_hot_cache import (
     CachedValue,
@@ -58,6 +59,45 @@ def client() -> Mock:
 
 
 @pytest.fixture
+def lease_client() -> Mock:
+    """A client that answers the vivify-on-miss (lease) variants of a get.
+
+    With the N flag the server always replies with a Value, never a Miss:
+    either the data, or a zero-sized placeholder flagged as won (W) or
+    lost (Z).
+    """
+
+    def meta_get(
+        key: Key,
+        flags: Optional[RequestFlags] = None,
+        failure_handling: FailureHandling = DEFAULT_FAILURE_HANDLING,
+    ) -> ReadResponse:
+        if key.key.endswith("win"):
+            # We got the lease: empty placeholder, we must repopulate.
+            return Value(size=0, value=None, flags=ResponseFlags(win=True))
+        elif key.key.endswith("lost"):
+            # Someone else holds the lease. The placeholder looks hot
+            # (fetched, recently accessed) but must never be promoted.
+            return Value(
+                size=0,
+                value=None,
+                flags=ResponseFlags(win=False, fetched=True, last_access=1),
+            )
+        elif key.key.endswith("hot"):
+            return Value(
+                size=1, value=1, flags=ResponseFlags(fetched=True, last_access=1)
+            )
+        else:
+            return Value(
+                size=1, value=1, flags=ResponseFlags(fetched=True, last_access=9999)
+            )
+
+    mock = Mock(spec=CacheClient)
+    mock.meta_get.side_effect = meta_get
+    return mock
+
+
+@pytest.fixture
 def time(monkeypatch) -> Mock:
     time_mock = Mock()
     monkeypatch.setattr("meta_memcache.extras.probabilistic_hot_cache.time", time_mock)
@@ -80,6 +120,19 @@ DEFAULT_FLAGS = {
         return_value=True,
         return_fetched=True,
         return_client_flag=True,
+    ),
+    "failure_handling": DEFAULT_FAILURE_HANDLING,
+}
+
+LEASE_FLAGS = {
+    "flags": RequestFlags(
+        return_ttl=True,
+        return_last_access=True,
+        return_value=True,
+        return_fetched=True,
+        return_client_flag=True,
+        return_cas_token=True,
+        vivify_on_miss_ttl=30,
     ),
     "failure_handling": DEFAULT_FAILURE_HANDLING,
 }
@@ -838,3 +891,208 @@ def test_cache_pollution_multi_get(
         "a": 1,
         "b": 2,
     }  # Not {"a": 1, "b": 2, "c": 3}
+
+
+def test_get_or_lease_uses_hot_cache(
+    time: Mock,
+    lease_client: Mock,
+) -> None:
+    store = {}
+    hot_cache = ProbabilisticHotCache(
+        client=lease_client,
+        store=store,
+        cache_ttl=60,
+        max_last_access_age_seconds=10,
+        probability_factor=1,
+        max_stale_while_revalidate_seconds=10,
+        allowed_prefixes=None,
+        immutable_types=[],
+    )
+    lease_policy = LeasePolicy()
+
+    time.time.return_value = 0
+
+    # A cold key is fetched from the server and not promoted
+    assert hot_cache.get_or_lease(key="foo_cold", lease_policy=lease_policy) == 1
+    assert "foo_cold" not in store
+    lease_client.meta_get.assert_called_once_with(
+        key=Key(key="foo_cold"), **LEASE_FLAGS
+    )
+    lease_client.meta_get.reset_mock()
+
+    # A hot key is fetched from the server and promoted to the hot cache
+    assert hot_cache.get_or_lease(key="foo_hot", lease_policy=lease_policy) == 1
+    assert store.get("foo_hot") == CachedValue(value=1, expiration=60, extended=False)
+    lease_client.meta_get.assert_called_once_with(key=Key(key="foo_hot"), **LEASE_FLAGS)
+    lease_client.meta_get.reset_mock()
+
+    time.time.return_value = 10
+
+    # The cold key still goes to the server every time
+    assert hot_cache.get_or_lease(key="foo_cold", lease_policy=lease_policy) == 1
+    lease_client.meta_get.assert_called_once_with(
+        key=Key(key="foo_cold"), **LEASE_FLAGS
+    )
+    lease_client.meta_get.reset_mock()
+
+    # The hot key is served locally: no lease needed, no call to the server
+    assert hot_cache.get_or_lease(key="foo_hot", lease_policy=lease_policy) == 1
+    lease_client.meta_get.assert_not_called()
+
+    # Once the local copy expires, it is refreshed through the lease path
+    time.time.return_value = 60
+
+    assert hot_cache.get_or_lease(key="foo_hot", lease_policy=lease_policy) == 1
+    assert store.get("foo_hot") == CachedValue(value=1, expiration=120, extended=False)
+    lease_client.meta_get.assert_called_once_with(key=Key(key="foo_hot"), **LEASE_FLAGS)
+
+
+def test_get_or_lease_does_not_promote_lease_placeholders(
+    time: Mock,
+    lease_client: Mock,
+) -> None:
+    store = {}
+    hot_cache = ProbabilisticHotCache(
+        client=lease_client,
+        store=store,
+        cache_ttl=60,
+        max_last_access_age_seconds=10,
+        probability_factor=1,
+        max_stale_while_revalidate_seconds=10,
+        allowed_prefixes=None,
+        immutable_types=[],
+    )
+
+    time.time.return_value = 0
+
+    # We won the lease: behaves as a miss, and the empty placeholder we
+    # planted on the server must not be cached locally.
+    assert hot_cache.get_or_lease(key="foo_win", lease_policy=LeasePolicy()) is None
+    assert "foo_win" not in store
+    lease_client.meta_get.reset_mock()
+
+    # We lost the lease and ran out of retries: same, even though the
+    # placeholder looks hot to the promotion heuristic.
+    wait = Mock()
+    assert (
+        hot_cache.get_or_lease(
+            key="foo_lost",
+            lease_policy=LeasePolicy(miss_retries=2),
+            lease_wait_fn=wait,
+        )
+        is None
+    )
+    assert "foo_lost" not in store
+    assert lease_client.meta_get.call_count == 2
+    wait.assert_called_once_with(1.0)
+
+
+def test_get_or_lease_stale_while_revalidate_elects_one_refresher(
+    time: Mock,
+    lease_client: Mock,
+) -> None:
+    store = {}
+    hot_cache = ProbabilisticHotCache(
+        client=lease_client,
+        store=store,
+        cache_ttl=60,
+        max_last_access_age_seconds=10,
+        probability_factor=1,
+        max_stale_while_revalidate_seconds=10,
+        allowed_prefixes=None,
+        immutable_types=[],
+    )
+    lease_policy = LeasePolicy()
+
+    time.time.return_value = 0
+    assert hot_cache.get_or_lease(key="foo_hot", lease_policy=lease_policy) == 1
+    lease_client.meta_get.reset_mock()
+
+    # The local copy is expired but still within the stale window: the first
+    # caller is elected to refresh (and takes the lease), the second serves
+    # the stale value without hitting the server.
+    time.time.return_value = 65
+
+    assert hot_cache.get_or_lease(key="foo_hot", lease_policy=lease_policy) == 1
+    lease_client.meta_get.assert_called_once_with(key=Key(key="foo_hot"), **LEASE_FLAGS)
+    lease_client.meta_get.reset_mock()
+
+    assert hot_cache.get_or_lease(key="foo_hot", lease_policy=lease_policy) == 1
+    lease_client.meta_get.assert_not_called()
+
+
+def test_get_or_lease_prefixes(
+    time: Mock,
+    lease_client: Mock,
+) -> None:
+    store = {}
+    metrics_collector = PrometheusMetricsCollector(
+        namespace="test", registry=CollectorRegistry()
+    )
+    hot_cache = ProbabilisticHotCache(
+        client=lease_client,
+        store=store,
+        cache_ttl=60,
+        max_last_access_age_seconds=10,
+        probability_factor=1,
+        max_stale_while_revalidate_seconds=10,
+        allowed_prefixes=["allowed:"],
+        metrics_collector=metrics_collector,
+        immutable_types=[],
+    )
+    lease_policy = LeasePolicy()
+
+    time.time.return_value = 0
+
+    assert hot_cache.get_or_lease(key="allowed:foo_hot", lease_policy=lease_policy) == 1
+    assert "allowed:foo_hot" in store
+
+    assert (
+        hot_cache.get_or_lease(key="allowed:foo_cold", lease_policy=lease_policy) == 1
+    )
+    assert "allowed:foo_cold" not in store
+
+    assert hot_cache.get_or_lease(key="other:foo_hot", lease_policy=lease_policy) == 1
+    assert "other:foo_hot" not in store
+
+    assert metrics_collector.get_counters() == {
+        "test_hot_cache_hits": 0,
+        "test_hot_cache_misses": 2,
+        "test_hot_cache_skips": 1,
+        "test_hot_cache_item_count": 1,
+        "test_hot_cache_hot_candidates": 1,
+        "test_hot_cache_hot_skips": 1,
+        "test_hot_cache_candidate_misses": 0,
+    }
+
+
+def test_get_or_lease_cas_bypasses_hot_cache(
+    time: Mock,
+    lease_client: Mock,
+) -> None:
+    store = {}
+    hot_cache = ProbabilisticHotCache(
+        client=lease_client,
+        store=store,
+        cache_ttl=60,
+        max_last_access_age_seconds=10,
+        probability_factor=1,
+        max_stale_while_revalidate_seconds=10,
+        allowed_prefixes=None,
+        immutable_types=[],
+    )
+    lease_policy = LeasePolicy()
+
+    time.time.return_value = 0
+
+    assert hot_cache.get_or_lease(key="foo_hot", lease_policy=lease_policy) == 1
+    assert "foo_hot" in store
+    lease_client.meta_get.reset_mock()
+
+    # A CAS token is only meaningful coming from the server, so the local
+    # copy is not used, same as get_cas().
+    assert hot_cache.get_or_lease_cas(key="foo_hot", lease_policy=lease_policy) == (
+        1,
+        None,
+    )
+    lease_client.meta_get.assert_called_once_with(key=Key(key="foo_hot"), **LEASE_FLAGS)

--- a/uv.lock
+++ b/uv.lock
@@ -211,7 +211,7 @@ wheels = [
 
 [[package]]
 name = "meta-memcache"
-version = "2.4.0"
+version = "2.5.0"
 source = { virtual = "." }
 dependencies = [
     { name = "marisa-trie" },


### PR DESCRIPTION
## Description

add `get_or_lease` support to `ProbabilisticHotCache`. Refactors the internal lease logic to make it easier to build wrappers that need to inspect raw response flags.

### Internal `_get_or_lease` method

`get_or_lease` and `get_or_lease_cas` previously duplicated the full lease retry loop. They now both delegate to a new internal `_get_or_lease` method that returns the raw `Value` object. This lets callers inspect response flags (e.g. `fetched`, `last_access`, `cas_token`) without re-running the loop.

This also simplifies how the `Value` needs to be processed. Leases have some placeholders and win flag that should behave as miss, and now all the handling is in `_process_get_result()`making sure the memcache response can't be misshandled and simplifying `_get_or_lease`.

### `ProbabilisticHotCache.get_or_lease`

`ProbabilisticHotCache` now overrides `get_or_lease`. A hot-cache hit short-circuits the call entirely. Requests that miss the local store fall through to `_get_or_lease` on the underlying client.

`get_or_lease_cas` intentionally bypasses the hot cache (matching the existing behaviour of `get_cas`), since a CAS token is only meaningful when it comes directly from the server. We might need to reconsider this is we shift to use get_cas more often, since will skip hot cache, and can cause performance problems.